### PR TITLE
New dp-zebedee-content repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you are running the publishing stack in terminals [dp-dimension-extractor](ht
 
 ### Zebedee
 
-Zebedee requires a very specific file structure in order to run along with additional environment variables. You can use [dp-zebedee-utils](https://github.com/ONSdigital/dp-zebedee-utils/tree/master/content) to simplify the setup process.
+Zebedee requires a very specific file structure in order to run along with additional environment variables. You can use [dp-zebedee-content](https://github.com/ONSdigital/dp-zebedee-content) to simplify the setup process.
 
 ### Licence
 


### PR DESCRIPTION
### What

Changed the readme me instructions to point to the new dp-zebedee-content repo instead of the do-zebedee-utils; content creation has been moved to this new repo

### How to review

View the markdown click the link

### Who can review

Anyone except me