### PR TITLE
Feature/ec2 running only; reformat

### DIFF
--- a/cmd/aws/ec2.go
+++ b/cmd/aws/ec2.go
@@ -432,6 +432,10 @@ func ListEC2(environment string) ([]EC2Result, error) {
 				Name:   aws.String("tag:Environment"),
 				Values: []*string{aws.String(environment)},
 			},
+			{
+				Name:   aws.String("instance-state-name"),
+				Values: []*string{aws.String(ec2.InstanceStateNameRunning)},
+			},
 		},
 	}
 

--- a/cmd/dp/main.go
+++ b/cmd/dp/main.go
@@ -20,11 +20,11 @@ func main() {
 
 	app := cli.NewApp()
 	app.Name = "dp"
-	app.Version = "0.1.0"
+	app.Version = "0.1.1"
 	app.Usage = "digital publishing helper command"
 
-	sshCommands := ssh.Command(cfg)
-	app.Commands = append(sshCommands,
+	app.Commands = append(
+		ssh.Command(cfg),
 		ui.Command(cfg),
 		remote.Command(cfg),
 		configCmd.Command(cfg),


### PR DESCRIPTION
### What

When listing ec2 (e.g. for ssh) instances, any terminated instances (e.g. via `terraform destroy`) were listed - this prevents that
Also adds colour and some formatting to the list of instances (including some red when accessing production).

### How to review

`dp ssh <env> <host_type>` should be limited to running instances, and should be nicely formatted (width, colour).

### Who can review

Anyone who uses `dp ssh` command.