### PR TITLE
Feature/ssh user profile

### DIFF
--- a/cmd/aws/aws.go
+++ b/cmd/aws/aws.go
@@ -4,8 +4,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
-func getAWSSession() *session.Session {
-	return session.Must(session.NewSessionWithOptions(session.Options{
+func getAWSSession(environment, profile string) *session.Session {
+	opts := session.Options{
 		SharedConfigState: session.SharedConfigEnable,
-	}))
+	}
+	if profile != "" {
+		opts.Profile = profile
+	}
+	return session.Must(session.NewSessionWithOptions(opts))
 }

--- a/cmd/aws/ec2.go
+++ b/cmd/aws/ec2.go
@@ -157,7 +157,7 @@ func AllowIPForConcourse(cfg config.Config) error {
 				IpProtocol: aws.String("tcp"),
 				FromPort:   aws.Int64(int64(443)),
 				ToPort:     aws.Int64(int64(443)),
-				IpRanges:   []*ec2.IpRange{{CidrIp: aws.String(myIP + "/32")}},
+				IpRanges:   getIpRangesFor(myIP, cfg.SSHUser),
 			},
 		},
 	})
@@ -194,7 +194,7 @@ func DenyIPForConcourse(cfg config.Config) error {
 				IpProtocol: aws.String("tcp"),
 				FromPort:   aws.Int64(int64(443)),
 				ToPort:     aws.Int64(int64(443)),
-				IpRanges:   []*ec2.IpRange{{CidrIp: aws.String(myIP + "/32")}},
+				IpRanges:   getIpRangesFor(myIP, cfg.SSHUser),
 			},
 		},
 	})
@@ -241,13 +241,13 @@ func DenyIPForEnvironment(cfg config.Config, environment string) error {
 				IpProtocol: aws.String("tcp"),
 				FromPort:   aws.Int64(int64(22)),
 				ToPort:     aws.Int64(int64(22)),
-				IpRanges:   []*ec2.IpRange{{CidrIp: aws.String(myIP + "/32")}},
+				IpRanges:   getIpRangesFor(myIP, cfg.SSHUser),
 			},
 			{
 				IpProtocol: aws.String("tcp"),
 				FromPort:   aws.Int64(int64(443)),
 				ToPort:     aws.Int64(int64(443)),
-				IpRanges:   []*ec2.IpRange{{CidrIp: aws.String(myIP + "/32")}},
+				IpRanges:   getIpRangesFor(myIP, cfg.SSHUser),
 			},
 		},
 	})
@@ -324,13 +324,13 @@ func AllowIPForEnvironment(cfg config.Config, environment string) error {
 				IpProtocol: aws.String("tcp"),
 				FromPort:   aws.Int64(int64(22)),
 				ToPort:     aws.Int64(int64(22)),
-				IpRanges:   []*ec2.IpRange{{CidrIp: aws.String(myIP + "/32")}},
+				IpRanges:   getIpRangesFor(myIP, cfg.SSHUser),
 			},
 			{
 				IpProtocol: aws.String("tcp"),
 				FromPort:   aws.Int64(int64(443)),
 				ToPort:     aws.Int64(int64(443)),
-				IpRanges:   []*ec2.IpRange{{CidrIp: aws.String(myIP + "/32")}},
+				IpRanges:   getIpRangesFor(myIP, cfg.SSHUser),
 			},
 		},
 	})
@@ -481,4 +481,13 @@ func ListEC2(environment string) ([]EC2Result, error) {
 	}
 
 	return resultCache[environment], nil
+}
+
+func getIpRangesFor(myIP, sshUser string) []*ec2.IpRange {
+	return []*ec2.IpRange{
+		{
+			CidrIp:      aws.String(myIP + "/32"),
+			Description: &sshUser,
+		},
+	}
 }

--- a/cmd/commands/remote/remote.go
+++ b/cmd/commands/remote/remote.go
@@ -47,12 +47,16 @@ func Command(cfg config.Config) cli.Command {
 	}
 	for _, e := range cfg.Environments {
 		var env = e
+		profile := cfg.DefaultEnvProfile
+		if e.Profile != "" {
+			profile = e.Profile
+		}
 		allowCmd.Subcommands = append(allowCmd.Subcommands, cli.Command{
 			Name:  env.Name,
 			Usage: "allow access to " + env.Name,
 			Action: func(c *cli.Context) error {
 				log.Println("allow access to " + env.Name)
-				return aws.AllowIPForEnvironment(cfg, env.Name)
+				return aws.AllowIPForEnvironment(cfg, env.Name, profile)
 			},
 		})
 		denyCmd.Subcommands = append(denyCmd.Subcommands, cli.Command{
@@ -60,7 +64,7 @@ func Command(cfg config.Config) cli.Command {
 			Usage: "denying access to " + env.Name,
 			Action: func(c *cli.Context) error {
 				log.Println("deny access to " + env.Name)
-				return aws.DenyIPForEnvironment(cfg, env.Name)
+				return aws.DenyIPForEnvironment(cfg, env.Name, profile)
 			},
 		})
 	}

--- a/cmd/commands/ssh/ssh.go
+++ b/cmd/commands/ssh/ssh.go
@@ -43,6 +43,11 @@ func Command(cfg config.Config) []cli.Command {
 		// 	Usage: "scp to " + env.Name,
 		// }
 
+		profile := cfg.DefaultEnvProfile
+		if e.Profile != "" {
+			profile = e.Profile
+		}
+
 		groups, err := ansible.GetGroupsForEnvironment(cfg, env.Name)
 		if err != nil {
 			fmt.Printf("error loading ansible hosts for %s: %s\n", env.Name, err)
@@ -76,7 +81,7 @@ func Command(cfg config.Config) []cli.Command {
 				fmt.Println("ssh to " + colAlt + grp + colReset + " in " + colEnv + env.Name + colReset)
 				// }
 
-				r, err := aws.ListEC2ByAnsibleGroup(env.Name, grp)
+				r, err := aws.ListEC2ByAnsibleGroup(env.Name, profile, grp)
 				if err != nil {
 					return fmt.Errorf("error fetching ec2: %s", err)
 				}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -20,6 +20,8 @@ type Config struct {
 
 	SetupRepo string `yaml:"setupRepo"`
 
+	DefaultEnvProfile string `yaml:"default_env_profile"`
+
 	GoPath  string `yaml:"-"`
 	SSHUser string `yaml:"-"`
 }
@@ -32,7 +34,8 @@ type App struct {
 
 // Environment represents an environment
 type Environment struct {
-	Name string `yaml:"name"`
+	Name    string `yaml:"name"`
+	Profile string `yaml:"profile"`
 }
 
 // GetDPSetupPath resolves the location of the dp-setup repo


### PR DESCRIPTION
### What

1. add DP_SSH_USER value to description of AWS security group allow/deny for better clarity (documentation) and safety (untested - might stop deletion if description differs?)

2. add (aws) env.profile (with default) to DP_CONFIG for per-env profile

DP_CONFIG now allows, for example:

```
default_env_profile: develop

environments:
  - name: develop
  - name: production
    profile: production
  - name: sandpit
  - name: bleed
```

first wins:  DP_CONFIG / $AWS_PROFILE / $AWS_DEFAULT_PROFILE / default

### How to review

modify your $DP_CONFIG (or not) and see if you can still login to AWS envs

### Who can review

`dp ssh` users - not @gedge