### PR TITLE
sort names for ssh, arg now counts from 1 (not index/0)

### DIFF
--- a/cmd/aws/ec2.go
+++ b/cmd/aws/ec2.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	cli "gopkg.in/urfave/cli.v1"
@@ -480,6 +481,7 @@ func ListEC2(environment, profile string) ([]EC2Result, error) {
 		}
 	}
 
+	sort.Slice(resultCache[environment], func(i, j int) bool { return resultCache[environment][i].Name < resultCache[environment][j].Name })
 	return resultCache[environment], nil
 }
 


### PR DESCRIPTION
### What

`dp ssh <env> <group> [<number>]`

- sorts its ouput by name
- numbers output/options from 1..n (not 0..n-1)
- interprets `<number>` as 1..n (as per previous point)

e.g.

```
$ dp ssh production consul
ssh to consul in production
[ 1] production - consul 1         : 10.30.41.29     [consul nomad]
[ 2] production - consul 2         : 10.30.41.77     [consul nomad]
[ 3] production - consul 3         : 10.30.41.136    [consul nomad]
use an number to select a specific instance

$ dp ssh production consul 1
ssh to consul in production
[ 1] production - consul 1         : 10.30.41.29     [consul nomad]
...
You@ip-10.30.41.29:~$ _
```

Enjoy the sanity where option '1' is now 'consul 1', etc  🎉 

### How to review

`cd cmd && make install`
then run your usual `dp ssh ...` commands, but notice the sorting and use of a count (and not an _index_)

### Who can review

Any other lovers of the `dp` command out there...?  Anyone?
