### PR TITLE
update dataset exporter cmd and remove superfluous line on

### DIFF
--- a/guides/GETTING_STARTED.md
+++ b/guides/GETTING_STARTED.md
@@ -165,15 +165,13 @@ If you already have content, and you just want to run the web journey, you'll ne
 * [dp-dataset-exporter](https://github.com/ONSdigital/dp-dataset-exporter)
   * use `$ make debug`
 * [dp-dataset-exporter-xlsx](https://github.com/ONSdigital/dp-dataset-exporter-xlsx)
-  * use `$ ./run.sh`
+  * use `$ make debug`
 * [dp-download-service](https://github.com/ONSdigital/dp-download-service)
   * use `$ make debug`
 
 [dp-api-router](https://github.com/ONSdigital/dp-api-router) locally as well.
   * use `$ make debug`
 
-
-The majority of these apps will run with `make debug`, except the XLSX exporter which requires `./run.sh`
 
 ### iTerm2 setup
   - Any terminal can be used however there are advantages of using iTerm2 such as badges, profiles, arrangements, multiple panes, ability to send commands to all panes.


### PR DESCRIPTION
### What

Update run command for `dp-dataset-exporter-xlsx` to `make debug` as the `./run.sh` script is superfluous.

Also removed the sentence about the majority of apps using `make debug` as this feels unnecessary now.

### How to review

- Check the changes made are logical

### Who can review

Anyone but me
