### PR TITLE
remove setting elasticsearch to local env in GETTING_STARTED.md

### DIFF
--- a/guides/GETTING_STARTED.md
+++ b/guides/GETTING_STARTED.md
@@ -93,8 +93,6 @@ users. Alternatively set this to `false` if wanting to bypass this.
 
 - `DATASET_ROUTES_ENABLED` should be set to `true` this will enable the filterable dataset routes.
 
-- `ELASTIC_SEARCH_URL` should be set to `http://localhost:9500` this will enable two versions of Elastic Search to run in the dp-compose tool.
-
 #### Installations
 
 * [Java 8 JDK (OpenJDK)](https://openjdk.java.net/install/)


### PR DESCRIPTION
### What

**Describe what you have changed and why.**
- Remove the description about setting `elasticsearch` in the local environment within the `GETTING_STARTED.md` file. 
For most services, `elasticsearch` is the OTHER instance of ES (ES5) which is defaulted to `10200/10300`. If `elasticsearch` URL is set to `localhost:9500`, it would break some services such as dp-search-query without realising. 

### How to review

**Describe the steps required to test the changes.**
- Check if the description has been removed correctly

### Who can review

**Describe who worked on the changes, so that other people can review.**
Anyone - Justin made the changes