### PR TITLE
update GPG README with additional configs

### DIFF
--- a/guides/GPG.md
+++ b/guides/GPG.md
@@ -19,6 +19,9 @@ We use GPG to sign our commits.
 * Configure git:
   * `git config --global commit.gpgsign true`
   * `git config --global user.signingkey <YOUR_GPG_KEY_ID>`
+  * `git config --global user.name <YOUR_NAME>`
+  * `git config --global user.email <YOUR_EMAIL_SIGNED_IN_GITHUB>`
+  * After, you can double check the updated git config with `git config --list`
 * Add `no-tty` to the end of `~/.gnupg/gpg.conf` (for IntelliJ)
 * Commit something and push to GitHub
 * Check commit history on GitHub, should have 'Verified' badge


### PR DESCRIPTION
### What

**Describe what you have changed and why.**
- Add additional two configs to be added to git config when following the readme file
- Important to set `name` and `email` in git config so that git commit history contains the correct name and email from the user. If not set, it will default to the local system name and hostname - which isn't necessary neat or clear dependent on how the local system details have been set 

- Added a double check for the user following the README to be reassured that the configs have been set correctly

### How to review

**Describe the steps required to test the changes.**
- Just checking if the code makes sense

### Who can review

**Describe who worked on the changes, so that other people can review.**
Anyone - Justin made the changes