### PR TITLE
Add section to getting started for infrastructure and CI setup

### DIFF
--- a/guides/GETTING_STARTED.md
+++ b/guides/GETTING_STARTED.md
@@ -34,16 +34,18 @@ We've made a few attempts at simplifying these steps, but haven't converged on o
 
 :warning: All steps in this section link to private repositories. If the links don't work for you, revisit the steps in [setting up your mac](#set-up-your-mac-for-development-work) to ensure you're a member of our Github organization.
 
-These guides may contain some steps which have already been completed - there is no need to do anything twice, just skip to the next step of the guide.
+For all work in this area you will first need to:
+1. [Install ansible](https://github.com/ONSdigital/dp-setup/tree/master/ANSIBLE.md#install-ansible)
+2. [Configure access to servers](https://github.com/ONSdigital/dp-setup/tree/master/ANSIBLE.md#configure-access-to-servers)
 
 ### Infrastructure
 All infrastructure configuration is managed in [dp-setup](https://github.com/ONSdigital/dp-setup) and includes the following pieces of set up:
 1. Install the [prerequisites for terraform](https://github.com/ONSdigital/dp-setup/blob/develop/terraform/README.md#prerequisites)
-2. Install the [prerequisites for ansible](https://github.com/ONSdigital/dp-setup/blob/develop/ansible/README.md#prerequisites)
+2. Install any additional [dependencies for ansible](https://github.com/ONSdigital/dp-setup/blob/develop/ansible/README.md#prerequisites)
 
 ### Continuous Integration (CI)
 All CI configuration is managed in [dp-ci](https://github.com/ONSdigital/dp-ci) and includes the following pieces of set up:
-1. Check this [list of ansible prerequisites](https://github.com/ONSdigital/dp-ci/tree/master/ansible#prerequisites) and complete any steps not already performed
+1. Install any additional [dependencies for ansible](https://github.com/ONSdigital/dp-ci/tree/master/ansible#prerequisites)
 2. Install the `fly` command by going to the Concourse UI and selecting the Apple from the CLI list in the bottom right of the screen.
 
 -----

--- a/guides/GETTING_STARTED.md
+++ b/guides/GETTING_STARTED.md
@@ -25,10 +25,24 @@ We're working on some guides to outline our team culture, and some of our develo
 
 We've made a few attempts at simplifying these steps, but haven't converged on one way of doing things yet. The alternatives are detailed in our [developer setup](DEV_SETUP.md) guide. 
 
-# Usage guides
+### Usage guides
 1. (Optional) [Enable feedback form](https://github.com/ONSdigital/dp-frontend-dataset-controller#feedback-service)
 2.  [Publishing system guide](https://github.com/ONSdigital/florence/blob/develop/USAGE.md)
 3. [CMD import guide](#cmd-import-steps)
+
+# Set up for infrastructure & CI work
+
+In linking to other guides, there may be mentions of tasks that have already been completed as part of [setting up your mac](#set-up-your-mac-for-development-work), such as AWS or environment key setup. You do not need to perform these tasks again.
+
+### Infrastructure
+All infrastructure configuration is managed in [dp-setup](https://github.com/ONSdigital/dp-setup) and includes the following pieces of set up:
+1. Install the [prerequisites for terraform](https://github.com/ONSdigital/dp-setup/blob/develop/terraform/README.md#prerequisites)
+2. Install the [prerequisites for ansible](https://github.com/ONSdigital/dp-setup/blob/develop/ansible/README.md#prerequisites)
+
+### Continuous Integration (CI)
+All CI configuration is managed in [dp-ci](https://github.com/ONSdigital/dp-ci) and includes the following pieces of set up:
+1. Check this [list of ansible prerequisites](https://github.com/ONSdigital/dp-ci/tree/master/ansible#prerequisites) and complete any steps not already performed
+2. Install the `fly` command by going to the Concourse UI and selecting the Apple from the CLI list in the bottom right of the screen.
 
 -----
 

--- a/guides/GETTING_STARTED.md
+++ b/guides/GETTING_STARTED.md
@@ -32,7 +32,9 @@ We've made a few attempts at simplifying these steps, but haven't converged on o
 
 # Set up for infrastructure & CI work
 
-In linking to other guides, there may be mentions of tasks that have already been completed as part of [setting up your mac](#set-up-your-mac-for-development-work), such as AWS or environment key setup. You do not need to perform these tasks again.
+:warning: All steps in this section link to private repositories. If the links don't work for you, revisit the steps in [setting up your mac](#set-up-your-mac-for-development-work) to ensure you're a member of our Github organization.
+
+These guides may contain some steps which have already been completed - there is no need to do anything twice, just skip to the next step of the guide.
 
 ### Infrastructure
 All infrastructure configuration is managed in [dp-setup](https://github.com/ONSdigital/dp-setup) and includes the following pieces of set up:


### PR DESCRIPTION
### What

Add a section highlighting steps needed to complete infrastructure and CI work

### How to review

Check this seems a comprehensive list of things that would need to be setup to perform typical tasks in the dp-setup and dp-ci repo

### Who can review

anyone