### PR TITLE
Tiny update on documentation to correct port for web stack entry point

### DIFF
--- a/guides/INSTALLING.md
+++ b/guides/INSTALLING.md
@@ -165,7 +165,7 @@ Most applications can be run using the `make debug` command, but deviations are 
   If you need to edit content in Florence, [try this guide](https://github.com/ONSdigital/florence/blob/develop/USAGE.md)
 
 #### Web
-  - The website will be available at `http://localhost:22000`
+  - The website will be available at `http://localhost:20000`
 
 Return to the [Getting Started](https://github.com/ONSdigital/dp/blob/master/guides/GETTING_STARTED.md) guide for next steps.
 


### PR DESCRIPTION
### What

As per https://github.com/ONSdigital/dp/blob/master/guides/PORTS.md 
dp-frontend-router should be the entry point for the web stack (port 20000). However documentation had dp-dataset-api (22000) as the entry point.

### How to review

Double check I have listed the correct port and this is indeed now the correct entry point for the web stack

### Who can review

Anyone except me