### PR TITLE
Rewords and formats instructions, and fixes reference to run-reader.sh

### DIFF
--- a/guides/AWS_CREDENTIALS.md
+++ b/guides/AWS_CREDENTIALS.md
@@ -3,6 +3,8 @@ AWS credentials
 
 Our tooling uses AWS credential profiles to manage working with different AWS accounts. These AWS credentials are set in the `~/.aws/credentials` file as shown below.  **You must not have the AWS env vars set as this will break our tooling including dp cli, Terraform and Ansible.**
 
+Ask a Tech Lead for access to AWS if your account is not yet setup.
+
 Credentials file example
 ------------------------
 
@@ -27,7 +29,7 @@ Working with multiple profiles
 
 Our tooling, including dp cli, Terraform and Ansible, will select the correct profile automatically, provided your credentials are set as described above.
 
-You **must not** set environment variables for AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, as this will prevent our tooling accessing your credentials properly.
+You **must not** set environment variables for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, as this will prevent our tooling accessing your credentials properly.
 
 If you are running other commands however you will need to specify which profile to use. The following is the recommended approach that is safe to use with our tooling:
 

--- a/guides/GETTING_STARTED.md
+++ b/guides/GETTING_STARTED.md
@@ -10,7 +10,7 @@ We're working on some guides to outline our team culture, and some of our develo
 3. Set up your [GPG keys](https://github.com/ONSdigital/dp-ci/blob/master/gpg-keys/developers/README.md)* 
 4. Set up your [AWS credentials](AWS_CREDENTIALS.md)
 5. Install the [dp-cli](https://github.com/ONSdigital/dp-cli) tool
-6. Run `dp remote allow develop` to prove all your previous setup is correct
+6. Run `dp remote allow develop` to prove all your previous setup is correct. The output should include `[dp] allowing access to develop`. Ask for help if you encounter errors or warnings.
 7. Add [environment keys](https://github.com/ONSdigital/dp-ci/tree/master/gpg-keys#adding-a-gpg-key-to-your-keyring) to keychain. You'll need to ask someone for passphrases first.
 
 *If you cannot access this link, something has gone wrong in the previous step.
@@ -18,7 +18,7 @@ We're working on some guides to outline our team culture, and some of our develo
 # Install, configure and run services
 1. [Install the prerequisites](INSTALLING.md#prerequisites)
 2. [Clone the repositories](INSTALLING.md#clone-the-services)
-3. Follow this separate guide to [setup base content](https://github.com/ONSdigital/dp-zebedee-content#dp-zebedee-content)
+3. [Setup base content](https://github.com/ONSdigital/dp-zebedee-content#dp-zebedee-content)
 4. [Setup base environment configuration](INSTALLING.md#configuration)
 5. [Run the apps](INSTALLING.md#running-the-apps)
 6. [Update configuration](INSTALLING.md#setup-credentials) for your credentials

--- a/guides/INSTALLING.md
+++ b/guides/INSTALLING.md
@@ -1,5 +1,6 @@
 Install, configure and run services
 ===============
+
 As listed step-by-step in the [Getting Started](https://github.com/ONSdigital/dp/blob/master/guides/GETTING_STARTED.md) guide. **You must follow the steps in the Getting Started guide** to ensure steps not documented here are not missed.
 
 --------------
@@ -7,6 +8,7 @@ As listed step-by-step in the [Getting Started](https://github.com/ONSdigital/dp
 ## Prerequisites
 
 In the below, the installation of each app is typically one of:
+
 - use the `brew` command where provided, or
 - use the link to the website to follow the installation instructions, or
 - follow the link to the Github repo, where you should clone the repo and follow the instructions in the `README.md` file to install/run (within the repo directory)
@@ -53,7 +55,7 @@ Clone the GitHub repos for [web](#web-journey), [publishing](#publishing-journey
 
 - [Publishing](#publishing-journey) - The "publishing journey" gives you all the features of web together with an internal interface to update, preview and publish content. All content is encrypted and requires authentication.
 
-- [CMD](#cmd-journeys) - apps will support the filterable dataset journey, and would mean you have every possible service running. 
+- [CMD](#cmd-journeys) - apps will support the filterable dataset journey, and would mean you have every possible service running.
 
 ### Web Journey
 
@@ -91,12 +93,14 @@ All services listed in the [web journey](#web-journey) are required for the publ
   git clone git@github.com:ONSdigital/florence
   git clone git@github.com:ONSdigital/The-Train
   git clone git@github.com:ONSdigital/dp-api-router
-    ```
+  ```
 
 ### CMD Journeys
+
 All the services in the [web] and [publishing] journeys, as well as:
 
 #### Dataset journey:
+
 * [dp-dataset-api](https://github.com/ONSdigital/dp-dataset-api)
 * [dp-frontend-filter-dataset-controller](https://github.com/ONSdigital/dp-frontend-filter-dataset-controller)
 * [dp-frontend-geography-controller](https://github.com/ONSdigital/dp-frontend-geography-controller)
@@ -104,10 +108,11 @@ All the services in the [web] and [publishing] journeys, as well as:
   ```bash
   git clone git@github.com:ONSdigital/dp-dataset-api
   git clone git@github.com:ONSdigital/dp-frontend-filter-dataset-controller
-  git clone git@github.com:ONSdigital/dp-frontend-geography-controller`
+  git clone git@github.com:ONSdigital/dp-frontend-geography-controller
   ```
 
 #### Import services:
+
 * [dp-recipe-api](https://github.com/ONSdigital/dp-recipe-api)
 * [dp-import-api](https://github.com/ONSdigital/dp-import-api)
 * [dp-import-tracker](https://github.com/ONSdigital/dp-import-tracker)
@@ -120,16 +125,16 @@ All the services in the [web] and [publishing] journeys, as well as:
 * [dp-publishing-dataset-controller](https://github.com/ONSdigital/dp-publishing-dataset-controller)
 
   ```bash
-  git clone git@github.com:ONSdigital/dp-recipe-api`
-  git clone git@github.com:ONSdigital/dp-import-api`
-  git clone git@github.com:ONSdigital/dp-import-tracker`
-  git clone git@github.com:ONSdigital/dp-dimension-extractor`
-  git clone git@github.com:ONSdigital/dp-dimension-importer`
-  git clone git@github.com:ONSdigital/dp-observation-extractor`
-  git clone git@github.com:ONSdigital/dp-observation-importer`
-  git clone git@github.com:ONSdigital/dp-hierarchy-builder`
-  git clone git@github.com:ONSdigital/dp-search-builder`
-  git clone git@github.com:ONSdigital/dp-publishing-dataset-controller`
+  git clone git@github.com:ONSdigital/dp-recipe-api
+  git clone git@github.com:ONSdigital/dp-import-api
+  git clone git@github.com:ONSdigital/dp-import-tracker
+  git clone git@github.com:ONSdigital/dp-dimension-extractor
+  git clone git@github.com:ONSdigital/dp-dimension-importer
+  git clone git@github.com:ONSdigital/dp-observation-extractor
+  git clone git@github.com:ONSdigital/dp-observation-importer
+  git clone git@github.com:ONSdigital/dp-hierarchy-builder
+  git clone git@github.com:ONSdigital/dp-search-builder
+  git clone git@github.com:ONSdigital/dp-publishing-dataset-controller
   ```
 
 #### Filter journey:
@@ -142,13 +147,13 @@ All the services in the [web] and [publishing] journeys, as well as:
 * [dp-download-service](https://github.com/ONSdigital/dp-download-service)
 
   ```bash
-  git clone git@github.com:ONSdigital/dp-search-api`
-  git clone git@github.com:ONSdigital/dp-code-list-api`
-  git clone git@github.com:ONSdigital/dp-hierarchy-api`
-  git clone git@github.com:ONSdigital/dp-filter-api`
-  git clone git@github.com:ONSdigital/dp-dataset-exporter`
-  git clone git@github.com:ONSdigital/dp-dataset-exporter-xlsx`
-  git clone git@github.com:ONSdigital/dp-download-service`
+  git clone git@github.com:ONSdigital/dp-search-api
+  git clone git@github.com:ONSdigital/dp-code-list-api
+  git clone git@github.com:ONSdigital/dp-hierarchy-api
+  git clone git@github.com:ONSdigital/dp-filter-api
+  git clone git@github.com:ONSdigital/dp-dataset-exporter
+  git clone git@github.com:ONSdigital/dp-dataset-exporter-xlsx
+  git clone git@github.com:ONSdigital/dp-download-service
   ```
 
 Return to the [Getting Started](https://github.com/ONSdigital/dp/blob/master/guides/GETTING_STARTED.md) guide for next steps.

--- a/guides/INSTALLING.md
+++ b/guides/INSTALLING.md
@@ -178,7 +178,7 @@ When the startup files are updated, to load the new changes into your shell, eit
 
 You should put the below _env vars_ in your [startup file](#startup-file).
 
-Varialbe name | note
+Variable name | note
 --- | ---
 `zebedee_root` | path to your zebedee content, typically the directory the [dp-zebedee-content](https://github.com/ONSdigital/dp-zebedee-content) generation script points to when run
 `ENABLE_PRIVATE_ENDPOINTS` | set `true` when running services in publishing, unset for web mode

--- a/guides/INSTALLING.md
+++ b/guides/INSTALLING.md
@@ -21,12 +21,12 @@ Software | Install | Notes
 [Maven](https://maven.apache.org/)                        | `$ brew install maven`
 [Docker](https://www.docker.com/get-started)              | `$ brew cask install docker`
  Docker Compose                                           | `$ brew install docker-compose`
-[Cypher Shell](https://neo4j.com/docs/operations-manual/current/tools/cypher-shell/)                                | `$ brew install cypher-shell`
-[Node.js and npm](https://nodejs.org/en/)                 | Install the LTS version with: `$ brew install node@12`  | Append `export PATH="/usr/local/opt/node@12/bin:$PATH"` to the your `.zshrc` or `.basrc` file and restart your terminal.
+[Cypher Shell](https://neo4j.com/docs/operations-manual/current/tools/cypher-shell/)                                | `$ brew install cypher-shell` | deprecated (not needed if using Neptune over Neo4j)
+[Node.js and npm](https://nodejs.org/en/)                 | `$ brew install node@12` (LTS version) | Append `export PATH="/usr/local/opt/node@12/bin:$PATH"` to your startup files and restart your terminal.
 [GoConvey](https://github.com/smartystreets/goconvey#installation)  |
 [GhostScript](https://www.ghostscript.com/download.html)  |   `$ brew install ghostscript`                          | Required for [Babbage](https://github.com/onsdigital/babbage)
 [Vault](https://www.vaultproject.io/intro/getting-started/install.html) | `$ brew install hashicorp/tap/vault`      | Required for running Florence.
-[jq](https://stedolan.github.io/jq/)                      | `$ brew install jq`                                     | A handy JSON tool (for debugging website content)
+[jq](https://stedolan.github.io/jq/)                      | `$ brew install jq`                                     | A handy JSON tool (for debugging website content and much more)
 [yq](https://github.com/mikefarah/yq)                     |  `$ brew install yq`                                    | A handy YAML tool
 [dp-compose](https://github.com/ONSdigital/dp-compose)    | `$ git clone git@github.com:ONSdigital/dp-compose`      | See [`dp-compose` README](https://github.com/ONSdigital/dp-compose#dp-compose) for configuration of Docker Desktop resources
 
@@ -49,7 +49,7 @@ Return to the [Getting Started](https://github.com/ONSdigital/dp/blob/master/gui
 
 Clone the GitHub repos for [web](#web-journey), [publishing](#publishing-journey) and/or [CMD](#cmd-journeys) (Customise My Data).
 
-- [Web](#web-journey) - These apps make up the public facing website providing **read only access** to published content, and will be enough strictly to work on website content types other than filterable datasets (e.g. bulletins, articles, timeseries, datasets).
+- [Web](#web-journey) - These apps make up the public-facing website providing **read-only access** to published content, and will be enough strictly to work on website content types other than filterable datasets (e.g. bulletins, articles, timeseries, datasets).
 
 - [Publishing](#publishing-journey) - The "publishing journey" gives you all the features of web together with an internal interface to update, preview and publish content. All content is encrypted and requires authentication.
 
@@ -215,7 +215,7 @@ Return to the [Getting Started](https://github.com/ONSdigital/dp/blob/master/gui
 
 ## Running the apps
 
-Run [dp-compose](https://github.com/ONSdigital/dp-compose) using the `./run.sh` command (in the dp-compose repo) to run the supporting services. As well as `Vault`, e.g. `$ vault server -dev`.
+Run [dp-compose](https://github.com/ONSdigital/dp-compose) using the `$ ./run.sh` command (in the dp-compose repo) to run the supporting services. As well as Vault, e.g. `$ vault server -dev`.
 
 Most applications can be run using the `$ make debug` command, but deviations are all documented below:
 
@@ -248,7 +248,7 @@ and also run the following:
 
 Florence will be available at http://localhost:8081/florence/login
 
-The website will be available at http://localhost:8081 after a successful login into florence. Login details are in the [florence repository](https://github.com/ONSdigital/florence/blob/develop/USAGE.md).
+The website will be available at [http://localhost:8081](http://localhost:8081) after a successful login into florence. Login details are in the [florence repository](https://github.com/ONSdigital/florence/blob/develop/USAGE.md).
 
 
 ### CMD

--- a/guides/INSTALLING.md
+++ b/guides/INSTALLING.md
@@ -225,6 +225,7 @@ Run [dp-compose](https://github.com/ONSdigital/dp-compose) using the `$ ./run.sh
 Most applications can be run using the `$ make debug` command, but deviations are all documented below:
 
 ### Web
+
 Run all the services in the [web journey](#web-journey)
 
 * [babbage](https://github.com/ONSdigital/babbage) - use: `$ ./run.sh`

--- a/guides/INSTALLING.md
+++ b/guides/INSTALLING.md
@@ -14,52 +14,32 @@ In the below, the installation of each app is typically one of:
 **Note:** when indicating a command that should be run in your terminal, we use the `$` prefix to indicate your shell prompt.
 
 ---
-* [Java 8 JDK (OpenJDK)](https://openjdk.java.net/install/) - install via
-  - `$ brew cask install adoptopenjdk8`
-* [Maven](https://maven.apache.org/)
-  - `$ brew install maven`
-* [Docker](https://www.docker.com/get-started) and **Docker Compose**
 
-  - `$ brew cask install docker`
-  - `$ brew install docker-compose`
+Software | Install | Notes
+-------- | ------- | ----- |
+[Java 8 JDK (OpenJDK)](https://openjdk.java.net/install/) | `$ brew cask install adoptopenjdk8`
+[Maven](https://maven.apache.org/)                        | `$ brew install maven`
+[Docker](https://www.docker.com/get-started)              | `$ brew cask install docker`
+ Docker Compose                                           | `$ brew install docker-compose`
+[Cypher Shell](https://neo4j.com/docs/operations-manual/current/tools/cypher-shell/)                                | `$ brew install cypher-shell`
+[Node.js and npm](https://nodejs.org/en/)                 | Install the LTS version with: `$ brew install node@12`  | Append `export PATH="/usr/local/opt/node@12/bin:$PATH"` to the your `.zshrc` or `.basrc` file and restart your terminal.
+[GoConvey](https://github.com/smartystreets/goconvey#installation)  |
+[GhostScript](https://www.ghostscript.com/download.html)  |   `$ brew install ghostscript`                          | Required for [Babbage](https://github.com/onsdigital/babbage)
+[Vault](https://www.vaultproject.io/intro/getting-started/install.html) | `$ brew install hashicorp/tap/vault`      | Required for running Florence.
+[jq](https://stedolan.github.io/jq/)                      | `$ brew install jq`                                     | A handy JSON tool (for debugging website content)
+[yq](https://github.com/mikefarah/yq)                     |  `$ brew install yq`                                    | A handy YAML tool
+[dp-compose](https://github.com/ONSdigital/dp-compose)    | `$ git clone git@github.com:ONSdigital/dp-compose`      | See [`dp-compose` README](https://github.com/ONSdigital/dp-compose#dp-compose) for configuration of Docker Desktop resources
 
-* [Cypher Shell](https://neo4j.com/docs/operations-manual/current/tools/cypher-shell/)
-  - `$ brew install cypher-shell`
-* [Node.js and npm](https://nodejs.org/en/), install the LTS version with:
-
-  - `$ brew install node@12`
-  
-  - append `export PATH="/usr/local/opt/node@12/bin:$PATH"` to the your `.zshrc` or `.basrc` file and restart your terminal.
-
-* [dp-compose](https://github.com/ONSdigital/dp-compose)
-
-  `$ git clone git@github.com:ONSdigital/dp-compose`
-
-  NB. See `dp-compose` README for configuration of Docker Desktop resources
-
+[dp-compose](https://github.com/ONSdigital/dp-compose) runs the following services:
   - Services for Web
     - Elasticsearch 2.4.2
     - Highcharts
     - Postgres
-    - MathJax 
   - Services for CMD
     - MongoDB
     - Elasticsearch 5 (on non-standard port)
     - Kafka (plus required Zookeeper dependency)
-    - Neo4J
-* [GoConvey](https://github.com/smartystreets/goconvey#installation)
-* [GhostScript](https://www.ghostscript.com/download.html) - Required for [Babbage](https://github.com/onsdigital/babbage)
-
-  - `$ brew install ghostscript`
-* [Vault](https://www.vaultproject.io/intro/getting-started/install.html) - Required for running Florence.
-
-  - `$ brew install hashicorp/tap/vault`
-
-* [jq](https://stedolan.github.io/jq/) - a handy JSON tool (for debugging website content)
-  - `$ brew install jq`
-
-* [yq](https://github.com/mikefarah/yq) - a handy YAML tool
-  - `$ brew install yq`
+    - Neo4J (currently being replaced by [Neptune](https://github.com/ONSdigital/dp/blob/master/guides/NEPTUNE.md#migrating-from-neo4j-to-aws-neptune))
 
 Return to the [Getting Started](https://github.com/ONSdigital/dp/blob/master/guides/GETTING_STARTED.md) guide for next steps.
 
@@ -67,93 +47,109 @@ Return to the [Getting Started](https://github.com/ONSdigital/dp/blob/master/gui
 
 ## Clone the services
 
-Clone the GitHub repos for [web](#web-journey), [publishing](#publishing-journey) and/or [CMD](#cmd-journeys).
+Clone the GitHub repos for [web](#web-journey), [publishing](#publishing-journey) and/or [CMD](#cmd-journeys) (Customise My Data).
 
-- [Web](#web-journey) - These apps make up the public facing website providing read only access to published content, and will be enough strictly to work on website content types other than filterable datasets (e.g. bulletins, articles, timeseries, datasets). 
+- [Web](#web-journey) - These apps make up the public facing website providing **read only access** to published content, and will be enough strictly to work on website content types other than filterable datasets (e.g. bulletins, articles, timeseries, datasets).
 
 - [Publishing](#publishing-journey) - The "publishing journey" gives you all the features of web together with an internal interface to update, preview and publish content. All content is encrypted and requires authentication.
 
-- [CMD](#cmd-journeys) - apps will support the filterable dataset journey, and would mean you have every possible service running.
+- [CMD](#cmd-journeys) - apps will support the filterable dataset journey, and would mean you have every possible service running. 
 
 ### Web Journey
 
 * [babbage](https://github.com/ONSdigital/babbage)
-  - `$ git clone git@github.com:ONSdigital/babbage`
 * [zebedee](https://github.com/ONSdigital/zebedee)
-  - `$ git clone git@github.com:ONSdigital/zebedee`
 * [sixteens](https://github.com/ONSdigital/sixteens)
-  - `$ git clone git@github.com:ONSdigital/sixteens`
 * [dp-frontend-router](https://github.com/ONSdigital/dp-frontend-router)
-  - `$ git clone git@github.com:ONSdigital/dp-frontend-router`
 * [dp-frontend-renderer](https://github.com/ONSdigital/dp-frontend-renderer)
-  - `$ git clone git@github.com:ONSdigital/dp-frontend-renderer`
 * [dp-frontend-homepage-controller](https://github.com/ONSdigital/dp-frontend-homepage-controller)
-  - `$ git clone git@github.com:ONSdigital/dp-frontend-homepage-controller`
 * [dp-frontend-cookie-controller](https://github.com/ONSdigital/dp-frontend-cookie-controller)
-  - `$ git clone git@github.com:ONSdigital/dp-frontend-cookie-controller`
 * [dp-frontend-dataset-controller](https://github.com/ONSdigital/dp-frontend-dataset-controller)
-  - `$ git clone git@github.com:ONSdigital/dp-frontend-dataset-controller`
+
+  ```bash
+  git clone git@github.com:ONSdigital/babbage
+  git clone git@github.com:ONSdigital/zebedee
+  git clone git@github.com:ONSdigital/sixteens
+
+  git clone git@github.com:ONSdigital/dp-frontend-router
+  git clone git@github.com:ONSdigital/dp-frontend-renderer
+
+  git clone git@github.com:ONSdigital/dp-frontend-homepage-controller
+  git clone git@github.com:ONSdigital/dp-frontend-cookie-controller
+  git clone git@github.com:ONSdigital/dp-frontend-dataset-controller
+  ```
 
 ### Publishing Journey
 
-All services listed in [web](#web-journey) are required for the publishing journey. They are used for the preview functionality.
+All services listed in the [web journey](#web-journey) are required for the publishing journey. They are used for the preview functionality.
 
 * [florence](https://github.com/ONSdigital/florence)
-  - `$ git clone git@github.com:ONSdigital/florence`
-
-  Then work through the README.md in the florence directory.
 * [The-Train](https://github.com/ONSdigital/The-Train)
-  - `$ git clone git@github.com:ONSdigital/The-Train`
+* [dp-api-router](https://github.com/ONSdigital/dp-api-router)
+
+  ```bash
+  git clone git@github.com:ONSdigital/florence
+  git clone git@github.com:ONSdigital/The-Train
+  git clone git@github.com:ONSdigital/dp-api-router
+    ```
 
 ### CMD Journeys
+All the services in the [web] and [publishing] journeys, as well as:
 
 #### Dataset journey:
-* [dp-api-router](https://github.com/ONSdigital/dp-api-router)
-  - `$ git clone git@github.com:ONSdigital/dp-api-router`
 * [dp-dataset-api](https://github.com/ONSdigital/dp-dataset-api)
-  - `$ git clone git@github.com:ONSdigital/dp-dataset-api`
 * [dp-frontend-filter-dataset-controller](https://github.com/ONSdigital/dp-frontend-filter-dataset-controller)
-  - `$ git clone git@github.com:ONSdigital/dp-frontend-filter-dataset-controller`
 * [dp-frontend-geography-controller](https://github.com/ONSdigital/dp-frontend-geography-controller)
-  - `$ git clone git@github.com:ONSdigital/dp-frontend-geography-controller`
+
+  ```bash
+  git clone git@github.com:ONSdigital/dp-dataset-api
+  git clone git@github.com:ONSdigital/dp-frontend-filter-dataset-controller
+  git clone git@github.com:ONSdigital/dp-frontend-geography-controller`
+  ```
 
 #### Import services:
 * [dp-recipe-api](https://github.com/ONSdigital/dp-recipe-api)
-  - `$ git clone git@github.com:ONSdigital/dp-recipe-api`
 * [dp-import-api](https://github.com/ONSdigital/dp-import-api)
-  - `$ git clone git@github.com:ONSdigital/dp-import-api`
 * [dp-import-tracker](https://github.com/ONSdigital/dp-import-tracker)
-  - `$ git clone git@github.com:ONSdigital/dp-import-tracker`
 * [dp-dimension-extractor](https://github.com/ONSdigital/dp-dimension-extractor)
-  - `$ git clone git@github.com:ONSdigital/dp-dimension-extractor`
 * [dp-dimension-importer](https://github.com/ONSdigital/dp-dimension-importer)
-  - `$ git clone git@github.com:ONSdigital/dp-dimension-importer`
 * [dp-observation-extractor](https://github.com/ONSdigital/dp-observation-extractor)
-  - `$ git clone git@github.com:ONSdigital/dp-observation-extractor`
 * [dp-observation-importer](https://github.com/ONSdigital/dp-observation-importer)
-  - `$ git clone git@github.com:ONSdigital/dp-observation-importer`
 * [dp-hierarchy-builder](https://github.com/ONSdigital/dp-hierarchy-builder)
-  - `$ git clone git@github.com:ONSdigital/dp-hierarchy-builder`
 * [dp-search-builder](https://github.com/ONSdigital/dp-search-builder)
-  - `$ git clone git@github.com:ONSdigital/dp-search-builder`
 * [dp-publishing-dataset-controller](https://github.com/ONSdigital/dp-publishing-dataset-controller)
-  - `$ git clone git@github.com:ONSdigital/dp-publishing-dataset-controller`
+
+  ```bash
+  git clone git@github.com:ONSdigital/dp-recipe-api`
+  git clone git@github.com:ONSdigital/dp-import-api`
+  git clone git@github.com:ONSdigital/dp-import-tracker`
+  git clone git@github.com:ONSdigital/dp-dimension-extractor`
+  git clone git@github.com:ONSdigital/dp-dimension-importer`
+  git clone git@github.com:ONSdigital/dp-observation-extractor`
+  git clone git@github.com:ONSdigital/dp-observation-importer`
+  git clone git@github.com:ONSdigital/dp-hierarchy-builder`
+  git clone git@github.com:ONSdigital/dp-search-builder`
+  git clone git@github.com:ONSdigital/dp-publishing-dataset-controller`
+  ```
 
 #### Filter journey:
 * [dp-search-api](https://github.com/ONSdigital/dp-search-api)
-  - `$ git clone git@github.com:ONSdigital/dp-search-api`
 * [dp-code-list-api](https://github.com/ONSdigital/dp-code-list-api)
-  - `$ git clone git@github.com:ONSdigital/dp-code-list-api`
 * [dp-hierarchy-api](https://github.com/ONSdigital/dp-hierarchy-api)
-  - `$ git clone git@github.com:ONSdigital/dp-hierarchy-api`
 * [dp-filter-api](https://github.com/ONSdigital/dp-filter-api)
-  - `$ git clone git@github.com:ONSdigital/dp-filter-api`
 * [dp-dataset-exporter](https://github.com/ONSdigital/dp-dataset-exporter)
-  - `$ git clone git@github.com:ONSdigital/dp-dataset-exporter`
 * [dp-dataset-exporter-xlsx](https://github.com/ONSdigital/dp-dataset-exporter-xlsx)
-  - `$ git clone git@github.com:ONSdigital/dp-dataset-exporter-xlsx`
 * [dp-download-service](https://github.com/ONSdigital/dp-download-service)
-  - `$ git clone git@github.com:ONSdigital/dp-download-service`
+
+  ```bash
+  git clone git@github.com:ONSdigital/dp-search-api`
+  git clone git@github.com:ONSdigital/dp-code-list-api`
+  git clone git@github.com:ONSdigital/dp-hierarchy-api`
+  git clone git@github.com:ONSdigital/dp-filter-api`
+  git clone git@github.com:ONSdigital/dp-dataset-exporter`
+  git clone git@github.com:ONSdigital/dp-dataset-exporter-xlsx`
+  git clone git@github.com:ONSdigital/dp-download-service`
+  ```
 
 Return to the [Getting Started](https://github.com/ONSdigital/dp/blob/master/guides/GETTING_STARTED.md) guide for next steps.
 
@@ -182,7 +178,7 @@ When the startup files are updated, to load the new changes into your shell, eit
 
 You should put the below _env vars_ in your [startup file](#startup-file).
 
-VAR_NAME | note
+Varialbe name | note
 --- | ---
 `zebedee_root` | path to your zebedee content, typically the directory the [dp-zebedee-content](https://github.com/ONSdigital/dp-zebedee-content) generation script points to when run
 `ENABLE_PRIVATE_ENDPOINTS` | set `true` when running services in publishing, unset for web mode
@@ -195,29 +191,23 @@ VAR_NAME | note
 
 After all the various steps, here's an example set of exports and their values that you might now have in your [startup file](#startup-file):
 
-**# ONS services**
+```bash
+# Digital Publishing services
+export zebedee_root=~/Documents/website/zebedee-content/generated
+export ENABLE_PRIVATE_ENDPOINTS=true
+export ENABLE_PERMISSIONS_AUTH=true
+export ENCRYPTION_DISABLED=true
+export DATASET_ROUTES_ENABLED=true
+export FORMAT_LOGGING=true
+export SERVICE_AUTH_TOKEN="fc4089e2e12937861377629b0cd96cf79298a4c5d329a2ebb96664c88df77b67"
+export NEW_HOMEPAGE_ENABLED=true
 
-**export zebedee_root=~/Documents/website/zebedee-content/generated**
 
-**export TRANSACTION_STORE=$zebedee_root/zebedee/transactions**
+export TRANSACTION_STORE=$zebedee_root/zebedee/transactions
+export WEBSITE=$zebedee_root/zebedee/master
+export PUBLISHING_THREAD_POOL_SIZE=10
 
-**export WEBSITE=$zebedee_root/zebedee/master**
-
-**export PUBLISHING_THREAD_POOL_SIZE=10**
-
-**export ENABLE_PRIVATE_ENDPOINTS=true**
-
-**export ENABLE_PERMISSIONS_AUTH=true**
-
-**export ENCRYPTION_DISABLED=true**
-
-**export DATASET_ROUTES_ENABLED=true**
-
-**export FORMAT_LOGGING=true**
-
-**export SERVICE_AUTH_TOKEN="fc4089e2e12937861377629b0cd96cf79298a4c5d329a2ebb96664c88df77b67"**
-
-**export NEW_HOMEPAGE_ENABLED=true**
+```
 
 Return to the [Getting Started](https://github.com/ONSdigital/dp/blob/master/guides/GETTING_STARTED.md) guide for next steps.
 
@@ -225,27 +215,27 @@ Return to the [Getting Started](https://github.com/ONSdigital/dp/blob/master/gui
 
 ## Running the apps
 
-Before running web or publishing, please make sure to run [dp-compose](https://github.com/ONSdigital/dp-compose) using the `./run.sh` command (in the dp-compose repo) to run the supporting services.
+Run [dp-compose](https://github.com/ONSdigital/dp-compose) using the `./run.sh` command (in the dp-compose repo) to run the supporting services. As well as `Vault`, e.g. `$ vault server -dev`.
 
 Most applications can be run using the `$ make debug` command, but deviations are all documented below:
 
-#### Web
+### Web
+Run all the services in the [web journey](#web-journey)
 
-  - The website will be available at http://localhost:20000
-
-    after you run up all of the following:
 * [babbage](https://github.com/ONSdigital/babbage) - use: `$ ./run.sh`
-* [zebedee](https://github.com/ONSdigital/zebedee) - use: `./run-reader.sh`
-* [sixteens](https://github.com/ONSdigital/sixteens) - use: `./run.sh`
+* [zebedee](https://github.com/ONSdigital/zebedee) - use: `$ ./run-cms.sh`
+* [sixteens](https://github.com/ONSdigital/sixteens) - use: `$ ./run.sh`
 * [dp-frontend-router](https://github.com/ONSdigital/dp-frontend-router)
 * [dp-frontend-renderer](https://github.com/ONSdigital/dp-frontend-renderer)
 * [dp-frontend-homepage-controller](https://github.com/ONSdigital/dp-frontend-homepage-controller)
 * [dp-frontend-cookie-controller](https://github.com/ONSdigital/dp-frontend-cookie-controller)
 * [dp-frontend-dataset-controller](https://github.com/ONSdigital/dp-frontend-dataset-controller)
 
-#### Publishing
+The website will be available at http://localhost:20000
 
-Run all of the services in Web, BUT change the commands used to run babbage and zebedee to:
+### Publishing
+
+Run all of the services in the [web journey](#web-journey), **but** change the commands used to run babbage and zebedee to:
 
 * [babbage](https://github.com/ONSdigital/babbage) - use: `$ ./run-publishing.sh`
 * [zebedee](https://github.com/ONSdigital/zebedee) - use: `$ ./run.sh`
@@ -258,25 +248,30 @@ and also run the following:
 
 Florence will be available at http://localhost:8081/florence/login
 
-The website will be available at http://localhost:8081 (only available after a successful login into Florence - see the README.md in the florence directory)
+The website will be available at http://localhost:8081 after a successful login into florence. Login details are in the [florence repository](https://github.com/ONSdigital/florence/blob/develop/USAGE.md).
 
-  If you need to edit content in Florence, [try this guide](https://github.com/ONSdigital/florence/blob/develop/USAGE.md)
 
-#### CMD
+### CMD
 
-Services cloned in web/publishing that must be run with alternate commands:
-* [dp-frontend-router](https://github.com/ONSdigital/dp-frontend-router) - use: `$ make debug DATASET_ROUTES_ENABLED=true`
+All of the services in the [web](#web-journey), [publishing](#publishing-journey) and [CMD](#cmd-journeys) journeys need to be run for the full CMD journey to work. This journey includes importing data, publishing it and testing the public journey.
+
+Use the following alternative commands:
+
 * [florence](https://github.com/ONSdigital/florence) - use: `$ make debug ENABLE_DATASET_IMPORT=true ENCRYPTION_DISABLED=true`
-
-Other commands to be run with alternative commands:
+* [dp-frontend-router](https://github.com/ONSdigital/dp-frontend-router) - use: `$ make debug DATASET_ROUTES_ENABLED=true`
+* For every service in [dataset](#dataset-journey) and [filter](#filter-journey)- use: `make debug ENABLE_PRIVATE_ENDPOINTS=true`
 * [dp-dimension-extractor](https://github.com/ONSdigital/dp-dimension-extractor) - use: `$ make debug ENCRYPTION_DISABLED=true`
 * [dp-observation-extractor](https://github.com/ONSdigital/dp-observation-extractor) - use `$ make debug ENCRYPTION_DISABLED=true`
 
-All other services listed in [web](#web-journey) AND [publishing](#publishing-journey) should also be run with this CMD stack to get the full journey - to import data, publish it and then test the public journey.
+#### Web
 
-If you already have content, and you just want to run the web journey, you'll need the [dataset](#dataset-journey), [filter](#filter-journey) and [web](#web-journey) services.
+If you already have content, and you just want to run the web journey, you'll need the [dataset](#dataset-journey), [filter](#filter-journey) and [web](#web-journey) services. Again, use the commands:
 
-The publishing journey for CMD requires all of the services listed, including the [import](#import-services) and [publishing](#publishing-journey) services. To configure [dataset](#dataset-journey) and [filter](#filter-journey) services for use in publishing, export `ENABLE_PRIVATE_ENDPOINTS=true` for every service.
+* [florence](https://github.com/ONSdigital/florence) - use: `$ make debug ENABLE_DATASET_IMPORT=true ENCRYPTION_DISABLED=true`
+* [dp-frontend-router](https://github.com/ONSdigital/dp-frontend-router) - use: `$ make debug `
+* unset `ENABLE_PRIVATE_ENDPOINTS`
+
+
 
 Return to the [Getting Started](https://github.com/ONSdigital/dp/blob/master/guides/GETTING_STARTED.md) guide for next steps.
 
@@ -284,9 +279,7 @@ Return to the [Getting Started](https://github.com/ONSdigital/dp/blob/master/gui
 
 ## Setup credentials
 
-To run florence, you will need to update the environment variable `SERVICE_AUTH_TOKEN` in your [startup file](#startup-file) by following:
-
-* Service authentication token creation steps can be found in the [Zebedee repository](https://github.com/ONSdigital/zebedee/#service-authentication-with-zebedee)
+To run florence, you will need to update the environment variable `SERVICE_AUTH_TOKEN` in your [startup file](#startup-file). Steps for creating the service authentication token can be found in the [Zebedee repository](https://github.com/ONSdigital/zebedee/#service-authentication-with-zebedee).
 
 You will need to restart your terminal for the environment variable change to take effect.
 

--- a/guides/MAC_SETUP.md
+++ b/guides/MAC_SETUP.md
@@ -112,23 +112,25 @@ Our code - in git repositories - is shared via [Github](https://github.com), so 
     * `$ git config --global user.name "<YOUR_NAME>"`
     * `$ git config --global user.email <YOUR_EMAIL_IN_GITHUB>`
 
-5. Making `git` work over `ssh`. In your home directory, run these commands:
-    * `$ ssh-keygen` and write down the passphrase you enter (somewhere _very_ safe)
-    * `$ cat ~/.ssh/id_rsa.pub`
+---
 
-  - Copy the displayed public key to your clipboard.
 
-Then follow instructions to add the SSH key in the clip board to your github account:
-	https://help.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account
+Making `git` work over `SSH`
+---
+
+In your home directory, run these commands:
+
+  * `$ ssh-keygen` and write down the passphrase you enter (somewhere _very_ safe)
+
+  * `$ cat ~/.ssh/id_rsa.pub`
+
+Copy the displayed public key to your clipboard.
+
+Then follow [instructions to add the SSH key in the clipboard to your github account](https://help.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account)
 
 Return to the [Getting Started](https://github.com/ONSdigital/dp/blob/master/guides/GETTING_STARTED.md) guide for next steps.
 
-----------
-
-Setting up SSH
----
-
-# Background
+### Background
 
 SSH (secure shell) is an encryption system for network communications (usually between client-server).
 
@@ -153,8 +155,3 @@ In all cases, the receiver of the data must already have your **public key**. So
 
 In DP, we use `ssh` to login to remote machines (including our servers in the cloud), and also to secure
 our communication with Github.
-
-Making `git` work over `ssh`. In your home directory, run these commands:
-    * `ssh-keygen` and write down the passphrase you enter (somewhere _very_ safe)
-
-Return to the [Getting Started](https://github.com/ONSdigital/dp/blob/master/guides/GETTING_STARTED.md) guide for next steps.


### PR DESCRIPTION
### What
After following the [getting started guide](https://github.com/ONSdigital/dp/blob/master/guides/GETTING_STARTED.md), I've made some changes that will hopefully make it slightly easier to follow. The changes: 
- metion Nepture migration
- add a table for prerequisites
- fix zebedee command (instructions now say run-cms.sh instead of run-reader.sh)
- change layout to make commands easier to copy
- re-arrange instructions for running CMD
- rearrange instructions for SSH mac setup

### How to review

Check that the instructions still make sense 😆. I'm particularly shaky on the bit about [running CMS](https://github.com/ONSdigital/dp/blob/feature/getting-started/guides/INSTALLING.md#cmd)

### Who can review

Any dev
