### PR TITLE
Mark old identity api service port as being unused.

### DIFF
--- a/guides/PORTS.md
+++ b/guides/PORTS.md
@@ -53,7 +53,7 @@ in development without having to configure port numbers etc.
 | 23500 | [dp-map-renderer](https://github.com/ONSdigital/dp-map-renderer) |
 | 23600 | [dp-developer-site](http://github.com/ONSdigital/dp-developer-site) |
 | 23700 | [dp-frontend-geography-controller](https://github.com/ONSdigital/dp-frontend-geography-controller) |
-| 23800 | [dp-identity-api](https://github.com/ONSdigital/dp-identity-api) |
+| 23800 | unused |
 | 23900 | [dp-search-api](https://github.com/ONSdigital/dp-search-api) |
 | 24000 | [dp-publishing-dataset-controller](https://github.com/ONSdigital/dp-publishing-dataset-controller) |
 | 24100 | [dp-frontend-cookie-controller](https://github.com/ONSdigital/dp-frontend-cookie-controller) |

--- a/guides/PORTS.md
+++ b/guides/PORTS.md
@@ -53,7 +53,6 @@ in development without having to configure port numbers etc.
 | 23500 | [dp-map-renderer](https://github.com/ONSdigital/dp-map-renderer) |
 | 23600 | [dp-developer-site](http://github.com/ONSdigital/dp-developer-site) |
 | 23700 | [dp-frontend-geography-controller](https://github.com/ONSdigital/dp-frontend-geography-controller) |
-| 23800 | unused |
 | 23900 | [dp-search-api](https://github.com/ONSdigital/dp-search-api) |
 | 24000 | [dp-publishing-dataset-controller](https://github.com/ONSdigital/dp-publishing-dataset-controller) |
 | 24100 | [dp-frontend-cookie-controller](https://github.com/ONSdigital/dp-frontend-cookie-controller) |


### PR DESCRIPTION
### What

See title.

### How to review

Old identity service port `23800` was unused (service archived), so ensure `guides/PORTS.md` reflects that.

### Who can review

Anyone but me.
