### PR TITLE
Add ability to have multiple errors per event

### DIFF
--- a/standards/LOGGING_STANDARDS.md
+++ b/standards/LOGGING_STANDARDS.md
@@ -1,39 +1,44 @@
 Logging standards
 =================
 
-## Libraries
+Libraries
+---------
 
 We have libraries the following libaries which match the logging standards defined below:
 
 * Go - [github.com/ONSdigital/log.go](https://github.com/ONSdigital/log.go)
 * Java - [com.github.onsdigital.logging](https://github.com/ONSdigital/dp-logging)
 * Javascript - [app/utilities/log.js](https://github.com/ONSdigital/florence/blob/develop/src/app/utilities/log.js)
-* Python - [dp4py_logging](https://github.com/ONSdigital/dp4py-logging)
 
-## What we should be logging
+What we should be logging
+-------------------------
 
 Apps should log all important events, especially failures, as well as enough events to be able to trace the execution logic through each major step without being overly noisy.  Any information which adds value is worth including in the event. **If you're unsure, log more rather than less.**
 
 A few ideas of useful things to log are:
-  * application startup (with sanitised application config output under `data`)
-  * log all failures
-  * http requests
-  * requests to data stores and other third party services (e.g. mongo, postgres, kafka, neptune, etc.)
-  * log events at significant steps throughout the execution flow
-    * sometimes it is useful to have `started x` and `finished x` for very long running events, but usually a single event can suffice
-    * avoid back to back log statements as a general rule, especially if the second event implies the first
+
+* application startup (with sanitised application config output under `data`)
+* log all failures
+* http requests
+* requests to data stores and other third party services (e.g. mongo, postgres, kafka, neptune, etc.)
+* log events at significant steps throughout the execution flow
+  * sometimes it is useful to have `started x` and `finished x` for very long running events, but usually a single event can suffice
+  * avoid back to back log statements as a general rule, especially if the second event implies the first
 
 Always consider the performance impact of logging:
-  * loops
-  * log-specific conditionals ("should I log this")
-  * JSON serialisation
-  * deeply nested data structures
 
-## Sensitive information
+* loops
+* log-specific conditionals ("should I log this")
+* JSON serialisation
+* deeply nested data structures
+
+Sensitive information
+---------------------
 
 **NEVER** log passwords, credentials, auth headers, or other sensitive information in any form.
 
-## Logging specification
+Logging specification
+---------------------
 
 We have defined the formatting and data structures, including field names and types, we use for logging.
 
@@ -60,19 +65,19 @@ Although "human readable" formatting is useful for local development, all apps d
 
 The following are the only top level fields. If you have app specific details you wish to add, it is likely that they should be added under `data` rather than creating a new field.
 
-| Field name   | Required       | Type                         | Example                      | Description
-| ------------ | -------------- | ---------------------------- | ---------------------------- | -----------------------------
-| `created_at` | Yes            | `datetime`<sup>1</sup>       | `"2019-01-21T16:19:12.356Z"` | Date and time of the log event (ISO8601 extended date and time string)
-| `namespace`  | Yes            | `string`                     | `"dp-frontend-router"`       | Service name or other identifier
-| `event`      | Yes            | `string`                     | `"connecting to mongodb"`    | [The event being logged](#effective-event-types)
-| `trace_id`   | No<sup>2</sup> | `string`                     |                              | [Trace ID from OpenCensus](https://opencensus.io/tracing/span/traceid/)
-| `span_id`    | No             | `string`                     |                              | [Span ID from OpenCensus](https://opencensus.io/tracing/span/spanid/)
-| `severity`   | No             | `int8`                       | `2`                          | [The event severity level code](#severity-levels)
-| `http`       | No             | [`http`](#http-event-data)   |                              | [HTTP event data](#http-event-data)
-| `auth`       | No             | [`auth`](#auth-event-data)   |                              | [Authentication event data](#auth-event-data)
-| `error`      | No             | [`error`](#error-event-data) |                              | [Error event data](#error-event-data)
-| `raw`        | No             | `string`                     |                              | [Log message captured from a third party library](#third-party-logs)
-| `data`       | No             | `object`<sup>3</sup>         |                              | [Arbitrary key-value pairs](#arbitrary-data-fields)
+| Field name   | Required       | Type                           | Example                      | Description                                                             |
+| ------------ | -------------- | ------------------------------ | ---------------------------- | ----------------------------------------------------------------------- |
+| `created_at` | Yes            | `datetime`<sup>1</sup>         | `"2019-01-21T16:19:12.356Z"` | Date and time of the log event (ISO8601 extended date and time string)  |
+| `namespace`  | Yes            | `string`                       | `"dp-frontend-router"`       | Service name or other identifier                                        |
+| `event`      | Yes            | `string`                       | `"connecting to mongodb"`    | [The event being logged](#effective-event-types)                        |
+| `trace_id`   | No<sup>2</sup> | `string`                       |                              | [Trace ID from OpenCensus](https://opencensus.io/tracing/span/traceid/) |
+| `span_id`    | No             | `string`                       |                              | [Span ID from OpenCensus](https://opencensus.io/tracing/span/spanid/)   |
+| `severity`   | No             | `int8`                         | `2`                          | [The event severity level code](#severity-levels)                       |
+| `http`       | No             | [`http`](#http-event-data)     |                              | [HTTP event data](#http-event-data)                                     |
+| `auth`       | No             | [`auth`](#auth-event-data)     |                              | [Authentication event data](#auth-event-data)                           |
+| `errors`     | No             | [`[]error`](#error-event-data) |                              | [Error event data](#error-event-data)                                   |
+| `raw`        | No             | `string`                       |                              | [Log message captured from a third party library](#third-party-logs)    |
+| `data`       | No             | `object`<sup>3</sup>           |                              | [Arbitrary key-value pairs](#arbitrary-data-fields)                     |
 
 <sup>1</sup> All dates must be UTC and in ISO8601 extended date time format with at least millisecond precision: `yyyy-MM-dd'T'HH:mm:ss.SSSZZ` (e.g. `2019-01-21T16:19:12.356Z`).
 
@@ -86,19 +91,19 @@ HTTP events are so common that we've defined a specific top-level field to captu
 
 This can be used to log inbound or outbound HTTP event data.
 
-| Field name                | Required | Type                   | Example                      | Description
-| ------------------------- | -------- | ---------------------- | ---------------------------- | -----------
-| `method`                  | Yes      | `string`               | `"GET"`                      | The HTTP method used
-| `scheme`                  | Yes      | `string`               | `"https"`                    | The scheme or protocol from the URL
-| `host`                    | Yes      | `string`               | `"10.100.20.1"`              | The hostname or ip from the URL
-| `port`                    | Yes      | `int32`                | `443`                        | The port number from the URL
-| `path`                    | Yes      | `string`               | `"/healthcheck"`             | The request path from the URL
-| `query`                   | No       | `string`               | `"x=1&y=1"`                  | The unparsed query string from the URL
-| `status_code`             | No       | `int16`                | `200`                        | The HTTP status code
-| `started_at`              | Yes      | `datetime`<sup>1</sup> | `"2019-01-21T16:19:12.356Z"` | ISO8601 date string of the request start time
-| `ended_at`                | No       | `datetime`<sup>1</sup> | `"2019-01-21T16:19:12.356Z"` | ISO8601 date string of the request end time
-| `duration`                | No       | `int64`                | `236578`                     | Difference between `started_at` and `ended_at` in nanoseconds
-| `response_content_length` | No       | `int64`                | `34`                         | The length of the response
+| Field name                | Required | Type                   | Example                      | Description                                                   |
+| ------------------------- | -------- | ---------------------- | ---------------------------- | ------------------------------------------------------------- |
+| `method`                  | Yes      | `string`               | `"GET"`                      | The HTTP method used                                          |
+| `scheme`                  | Yes      | `string`               | `"https"`                    | The scheme or protocol from the URL                           |
+| `host`                    | Yes      | `string`               | `"10.100.20.1"`              | The hostname or ip from the URL                               |
+| `port`                    | Yes      | `int32`                | `443`                        | The port number from the URL                                  |
+| `path`                    | Yes      | `string`               | `"/healthcheck"`             | The request path from the URL                                 |
+| `query`                   | No       | `string`               | `"x=1&y=1"`                  | The unparsed query string from the URL                        |
+| `status_code`             | No       | `int16`                | `200`                        | The HTTP status code                                          |
+| `started_at`              | Yes      | `datetime`<sup>1</sup> | `"2019-01-21T16:19:12.356Z"` | ISO8601 date string of the request start time                 |
+| `ended_at`                | No       | `datetime`<sup>1</sup> | `"2019-01-21T16:19:12.356Z"` | ISO8601 date string of the request end time                   |
+| `duration`                | No       | `int64`                | `236578`                     | Difference between `started_at` and `ended_at` in nanoseconds |
+| `response_content_length` | No       | `int64`                | `34`                         | The length of the response                                    |
 
 <sup>1</sup> All dates must be UTC and in ISO8601 extended date time format with at least millisecond precision: `yyyy-MM-dd'T'HH:mm:ss.SSSZZ` (e.g. `2019-01-21T16:19:12.356Z`).
 
@@ -106,20 +111,20 @@ This can be used to log inbound or outbound HTTP event data.
 
 The `auth` field defines the common auth event data.
 
-| Field name      | Required | Type                   | Example               | Description
-| --------------- | -------- | ---------------------- | --------------------- | -----------
-| `identity`      | Yes      | `string`               | `"dp-import-tracker"` | The user id or service id
-| `identity_type` | Yes      | `string`               | `"service"`           | The identity type (i.e. `user` or `service`)
+| Field name      | Required | Type     | Example               | Description                                  |
+| --------------- | -------- | -------- | --------------------- | -------------------------------------------- |
+| `identity`      | Yes      | `string` | `"dp-import-tracker"` | The user id or service id                    |
+| `identity_type` | Yes      | `string` | `"service"`           | The identity type (i.e. `user` or `service`) |
 
 #### Error event data
 
-The `error` field defines the common error event data.
+Errors are logged as an array. Each element of the array represents a single error and has the following fields.
 
-| Field name      | Required | Type                                    | Example               | Description
-| --------------- | -------- | --------------------------------------- | --------------------- | -----------
-| `message`       | Yes      | `string`                                |`"connection refused"` | The error cause
-| `stack_trace`   | No       | [`[]stack_trace`](#stack-trace-element) |                       | [Stack trace as an array](#stack-trace-element)
-| `data`          | No       | `object`<sup>1</sup>                    |                       | [Arbitrary key-value pairs](#arbitrary-data-fields)
+| Field name    | Required | Type                                    | Example                | Description                                         |
+| ------------- | -------- | --------------------------------------- | ---------------------- | --------------------------------------------------- |
+| `message`     | Yes      | `string`                                | `"connection refused"` | The error cause                                     |
+| `stack_trace` | No       | [`[]stack_trace`](#stack-trace-element) |                        | [Stack trace as an array](#stack-trace-element)     |
+| `data`        | No       | `object`<sup>1</sup>                    |                        | [Arbitrary key-value pairs](#arbitrary-data-fields) |
 
 <sup>1</sup> The error-specific details in `data` are input as an object/map in code, but are stored as a text string by the centralised logging service to allow additional detail to be added to an event without needing to worry about key name collision.  These details can still be searched using a general text search on the `data` field.
 
@@ -127,11 +132,11 @@ The `error` field defines the common error event data.
 
 The stack trace is logged as an array.  Each element of the array has the following fields.
 
-| Field name      | Required | Type      | Example                | Description
-| --------------- | -------- | --------- | ---------------------- | -----------
-| `file`          | No       | `string`  | `"/some/path/main.go"` | The source file containing the code throwing an error
-| `function`      | No       | `string`  | `"main.main"`          | The function in which the error is occurring
-| `line`          | No       | `int16`   | `18`                   | The line in the source file that is throwing the error
+| Field name | Required | Type     | Example                | Description                                            |
+| ---------- | -------- | -------- | ---------------------- | ------------------------------------------------------ |
+| `file`     | No       | `string` | `"/some/path/main.go"` | The source file containing the code throwing an error  |
+| `function` | No       | `string` | `"main.main"`          | The function in which the error is occurring           |
+| `line`     | No       | `int16`  | `18`                   | The line in the source file that is throwing the error |
 
 ### Effective `event` types
 
@@ -147,14 +152,14 @@ A good `event` description is:
 
 For example:
 
-```
+```text
 'event': 'file could not be read from s3'
 ```
 
 These are guidelines only - there are some exceptions where it's ok to ignore them, for example when
 using uppercase to refer to a constant or environment variable:
 
-```
+```text
 'event': 'DEBUG is not a boolean'
 ```
 
@@ -164,12 +169,12 @@ The event severity levels are used to identify how critical an event is, especia
 
 There are four severity levels:
 
-| Code | Severity | Description
-| ---- | -------- | -----------
-| 0    | FATAL    | An catastrophic failure event resulting in the death of the application
-| 1    | ERROR    | An unrecoverable failure event that halts the current flow of execution
-| 2    | WARN     | A failure event that can be managed within the current flow of execution (e.g. retried)
-| 3    | INFO     | All non-failure events
+| Code | Severity | Description                                                                             |
+| ---- | -------- | --------------------------------------------------------------------------------------- |
+| 0    | FATAL    | An catastrophic failure event resulting in the death of the application                 |
+| 1    | ERROR    | An unrecoverable failure event that halts the current flow of execution                 |
+| 2    | WARN     | A failure event that can be managed within the current flow of execution (e.g. retried) |
+| 3    | INFO     | All non-failure events                                                                  |
 
 For example, if in the process of serving an HTTP request an action is retried three times, the first two failures would have a severity of `WARN`, whereas the third time would have an `ERROR`.
 
@@ -179,7 +184,7 @@ The [log libraries](#libraries) attempt to intercept all logs from third party l
 
 For example:
 
-```
+```json
 {
   "created_at" : "2019-02-01T13:45:24.157Z",
   "namespace" : "my-app",


### PR DESCRIPTION
### What

When implementing the Java library it was recognised that a single event
may actually have more than one underlying error. In light of this the
Java implementation opted to change the singular `error` field to an
`errors` array.

This change to the spec is to align to that change and to move towards
consistency between all of our implementations.

### Who can review

Anyone but me.
