### PR TITLE
Rename dp-search-builder

### DIFF
--- a/guides/INSTALLING.md
+++ b/guides/INSTALLING.md
@@ -121,7 +121,7 @@ All the services in the [web] and [publishing] journeys, as well as:
 * [dp-observation-extractor](https://github.com/ONSdigital/dp-observation-extractor)
 * [dp-observation-importer](https://github.com/ONSdigital/dp-observation-importer)
 * [dp-hierarchy-builder](https://github.com/ONSdigital/dp-hierarchy-builder)
-* [dp-search-builder](https://github.com/ONSdigital/dp-search-builder)
+* [dp-dimension-search-builder](https://github.com/ONSdigital/dp-dimension-search-builder)
 * [dp-publishing-dataset-controller](https://github.com/ONSdigital/dp-publishing-dataset-controller)
 
   ```bash
@@ -133,7 +133,7 @@ All the services in the [web] and [publishing] journeys, as well as:
   git clone git@github.com:ONSdigital/dp-observation-extractor
   git clone git@github.com:ONSdigital/dp-observation-importer
   git clone git@github.com:ONSdigital/dp-hierarchy-builder
-  git clone git@github.com:ONSdigital/dp-search-builder
+  git clone git@github.com:ONSdigital/dp-dimension-search-builder
   git clone git@github.com:ONSdigital/dp-publishing-dataset-controller
   ```
 

--- a/guides/PORTS.md
+++ b/guides/PORTS.md
@@ -45,7 +45,7 @@ in development without having to configure port numbers etc.
 | 22600 | [dp-hierarchy-api](https://github.com/ONSdigital/dp-hierarchy-api) |
 | 22700 | [dp-hierarchy-builder](https://github.com/ONSdigital/dp-hierarchy-builder) |
 | 22800 | [dp-dataset-exporter-xlsx](https://github.com/ONSdigital/dp-dataset-exporter-xlsx) |
-| 22900 | [dp-search-builder](https://github.com/ONSdigital/dp-search-builder) |
+| 22900 | [dp-dimension-search-builder](https://github.com/ONSdigital/dp-dimension-search-builder) |
 | 23100 | [dp-dimension-search-api](https://github.com/ONSdigital/dp-dimension-search-api) |
 | 23200 | [dp-api-router](https://github.com/ONSdigital/dp-api-router) |
 | 23300 | [dp-table-renderer](https://github.com/ONSdigital/dp-table-renderer) |

--- a/websysd/dp-run.sh
+++ b/websysd/dp-run.sh
@@ -76,7 +76,7 @@ clone() {
     cloneGoRepo "dp-observation-extractor"
     cloneGoRepo "dp-observation-importer"
     cloneGoRepo "dp-recipe-api"
-    cloneGoRepo "dp-search-builder"
+    cloneGoRepo "dp-dimension-search-builder"
     cloneGoRepo "dp-search-api"
     cloneGoRepo "dp-dimension-search-api"
     cloneGoRepo "florence"
@@ -127,7 +127,7 @@ pull() {
     pullGoRepo "dp-recipe-api"
     pullGoRepo "dp-search-api"
     pullGoRepo "dp-dimension-search-api"
-    pullGoRepo "dp-search-builder"
+    pullGoRepo "dp-dimension-search-builder"
     pullGoRepo "florence"
 
     pullRepo "babbage" 


### PR DESCRIPTION
### What

Renamed `dp-search-builder` to `dp-dimension-search-builder`
NB. Links will be temporarily broken as the repo hasn't been renamed yet.

### How to review

Check changes make sense

### Who can review

Anyone but me