### PR TITLE
Add link to dependency upgrade documentation from root README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Standards and specifications
 * [API standards](standards/API_STANDARDS.md)
 * [Logging standards](standards/LOGGING_STANDARDS.md)
 * [Health check specification](standards/HEALTH_CHECK_SPECIFICATION.md)
+* [Dependency upgrades](standards/DEPENDENCY_UPGRADING.md)
 
 Dev tooling
 -----------


### PR DESCRIPTION
### What

See title

### How to review

Check link between README.md roots to the standards dependency upgrade documentation

### Who can review

Anyone
