### PR TITLE
Add crucial CMD prereqs to import guide

### DIFF
--- a/guides/GETTING_STARTED.md
+++ b/guides/GETTING_STARTED.md
@@ -53,6 +53,8 @@ All CI configuration is managed in [dp-ci](https://github.com/ONSdigital/dp-ci) 
 #### CMD import steps
 
 1. [Import recipes](https://github.com/ONSdigital/dp-recipe-api) using the `import-recipes` script
+1. [Import code lists](https://github.com/ONSdigital/dp-code-list-scripts) for the recipes you'll be using
+1. [Import hierarchies](https://github.com/ONSdigital/dp-hierarchy-builder) if needed by the recipes you'll be using
 2. [Create datasets](https://github.com/ONSdigital/florence/tree/develop/USAGE.md#create-a-cmd-dataset-page)
 3. [Import a file](https://github.com/ONSdigital/florence/tree/develop/USAGE.md#import-a-v4-file)
 4. [Publish a collection](https://github.com/ONSdigital/florence/tree/develop/USAGE.md#publish-a-collection)


### PR DESCRIPTION
### What

Without code lists CMD imports cannot happen, so they must be included in the documentation. Have added links to the repos, and the README.mds in there should explain what steps are required

### How to review

Check links work and point to the right thing

### Who can review

anyone
