### PR TITLE
Update links in guides to refer to new dp-operations guides area

### DIFF
--- a/guides/CONTRIBUTING.md
+++ b/guides/CONTRIBUTING.md
@@ -23,5 +23,5 @@ Contributing to Digital Publishing repos
 #### Note: if you get a 404 error for any of the below links, then you need to be added to the `ONSdigital` organisation in GitHub
 * For direct access to the environments
     * Setup your [AWS credentials](AWS_CREDENTIALS.md)
-    * Configure your [SSH access](https://github.com/ONSdigital/dp-setup/blob/develop/SSH-ACCESS.md)
+    * Configure your [SSH access](https://github.com/ONSdigital/dp-operations/blob/main/guides/ssh-access.md)
     * [Ansible](https://github.com/ONSdigital/dp-ci/tree/master/ansible#prerequisites) is required for provisioning to environments

--- a/guides/GETTING_STARTED.md
+++ b/guides/GETTING_STARTED.md
@@ -35,8 +35,8 @@ We've made a few attempts at simplifying these steps, but haven't converged on o
 :warning: All steps in this section link to private repositories. If the links don't work for you, revisit the steps in [setting up your mac](#set-up-your-mac-for-development-work) to ensure you're a member of our Github organization.
 
 For all work in this area you will first need to:
-1. [Install ansible](https://github.com/ONSdigital/dp-setup/tree/develop/ANSIBLE.md#install-ansible)
-2. [Configure access to servers](https://github.com/ONSdigital/dp-setup/tree/develop/ANSIBLE.md#configure-access-to-servers)
+1. [Install ansible](https://github.com/ONSdigital/dp-operations/blob/main/guides/ansible.md#install-ansible)
+2. [Configure access to servers](https://github.com/ONSdigital/dp-operations/blob/main/guides/ansible.md#configure-access-to-servers)
 
 ### Infrastructure
 All infrastructure configuration is managed in [dp-setup](https://github.com/ONSdigital/dp-setup) and includes the following pieces of set up:


### PR DESCRIPTION
### What

I noticed a broken link, so I did a search through the whole repo and hopefully caught all other instances of the issues. Many of the guides that lived in dp-setup have moved to dp-operations, so the links needed updating

### How to review

Check links resolve

### Who can review

anyone
