### PR TITLE
Remove dp-sessions-api from port

### DIFF
--- a/guides/PORTS.md
+++ b/guides/PORTS.md
@@ -59,7 +59,6 @@ in development without having to configure port numbers etc.
 | 24100 | [dp-frontend-cookie-controller](https://github.com/ONSdigital/dp-frontend-cookie-controller) |
 | 24200 | [dp-bulletin-api](https://github.com/ONSdigital/dp-bulletin-api) |
 | 24300 | [dp-deployer](https://github.com/ONSdigital/dp-deployer) |
-| 24400 | [dp-sessions-api](https://github.com/ONSdigital/dp-sessions-api) |
 | 24500 | [dp-observation-api](https://github.com/ONSdigital/dp-observation-api) |
 | 24600 | [dp-legacy-redirector](https://github.com/ONSdigital/dp-legacy-redirector) |
 | 24700 | [dp-image-api](https://github.com/ONSdigital/dp-image-api) |


### PR DESCRIPTION
### What

Remove dp-sessions-api from port list because it is no longer needed
### How to review

Check only dp-sessions-api port has been updated
### Who can review

Anyone