### PR TITLE
Add core services and microservice training modules and slides

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -24,13 +24,15 @@ Modules
 #### Architectural principles & approach
 * [Architectural principles](architecture/ARCHITECTURE_PRINCIPLES.md)
 * [12 Factor App principles](architecture/12_FACTOR_APP_PRINCIPLES.md)
+* [Microservices](architecture/MICROSERVICES.md)
+* [APIs](architecture/API.md)
 * [Common data terms](architecture/DATA_TERMS.md)
 * Security
 * Data modeling, what databases we use and when
 
 #### Our services
-* Web & Publishing Journeys
-* Microservices & Customise my Data Journey
+* [Web & Publishing Journeys](services/CORE_APPS.md)
+* :warning: WIP [Customise my Data Journey](services/CMD.md)
 * [Cloud technologies and Infrastructure (should this move to architecture?)](services/INFRASTRUCTURE.md)
 * [Platform Services](platform-services/PLATFORM.md)
 
@@ -41,6 +43,7 @@ Modules
     * Concurrency
 * AWS
     * Intro to AWS
+* Packer, Ansible and Terraform
 
 #### Testing
 * Our testing approach

--- a/training/architecture/API.md
+++ b/training/architecture/API.md
@@ -1,0 +1,20 @@
+API Architecture
+===========================
+
+Module description - why its relevant in our context
+
+### Pre-reading
+
+Understand our [microservice](MICROSERVICES.md) approach
+
+### Materials
+
+[This presentation](https://docs.google.com/presentation/d/1K7NN-oPn427Xc339s6NL3vbfNGPC62y3euhvRapwFf8/edit#slide=id.p) gives a basic introduction to what our API service is providing, why we care to make our APIs public and how we break down our microservices when it comes to API development. It also outlines some initial plans for API development required for Census work.
+
+Our [API standards](../../standards/API_STANDARDS.md) are also an important read to understand the full context needed to begin API development in our context. 
+
+
+Further resources
+----------------------------
+
+* [Developer Hub](https://developer.ons.gov.uk/) provides our public API documentation and instructions to get started using the APIs.

--- a/training/architecture/MICROSERVICES.md
+++ b/training/architecture/MICROSERVICES.md
@@ -1,0 +1,31 @@
+Microservice architecture
+===========================
+
+We use a microservice architecture in our approach to new system components as it provides a flexible, iterative and scalable way to solve new problems. Its worth understanding some basic theory around what a microservice architecture means, but also to get familiar with the service classes and terms we use when discussing these concepts.
+
+### Pre-reading
+
+To understand some of our pre-existing structures, and some of the problems we're trying to move past, it may be helpful to review our [core services](../services/CORE_APPS.md) training materials.
+
+
+### Prerequisites
+
+Understand a [basic definition of microservices](https://smartbear.com/solutions/microservices/)
+
+### Materials
+
+[This presentation](https://docs.google.com/presentation/d/1bXZw2rJTBa7spXVQNuA0lVQSN-2jZiz9khn6hJsvWwc/edit#slide=id.ge2b2dc2785_0_359) walks through our different service types and where they are commonly deployed. It also highlights some considerations and standards that are common across all of our service types, such as healthchecking.
+
+As microservices mean we often have to create new repositories, we have created a [project generation](https://github.com/ONSdigital/dp-cli/tree/main/project_generation) tool that allows us to start from a boilerplated version of the relevant kind of repository. We also have a [hello world](https://github.com/ONSdigital/dp-hello-world) repo where we document our baseline application structure for reference, review, and as a place to center conversations about standards.
+
+### Next steps
+
+[12 factor app](12_FACTOR_APP_PRINCIPLES.md) principles are a common set of considerations for building applications that can be deployed in a clean containerised way - and is very common in a microservice paradigm.
+
+[API](API.md) training will explain in more detail what our API microservices are responsible for. It will also link to relevant standards around API design and development.
+
+
+Further resources
+----------------------------
+
+* [Microservices.io](https://microservices.io/patterns/microservices.html)

--- a/training/services/CMD.md
+++ b/training/services/CMD.md
@@ -1,0 +1,30 @@
+Customize my Data Journey (WIP)
+===========================
+
+Module description - why its relevant in our context
+
+### Pre-reading
+
+Are there relevant standards to be aware of before undergoing this module? None if not needed.
+
+### Prerequisites
+
+Need to do before doing this course. None if not needed.
+
+### Materials
+
+TODO:
+* :warning: [These slides](https://docs.google.com/presentation/d/1bXZw2rJTBa7spXVQNuA0lVQSN-2jZiz9khn6hJsvWwc/edit#slide=id.ge3df80403a_0_0) need updating
+* provide links to explore the journey
+
+Module content or link to it. For self-learning this may be a text explanation of an area with links to a few relevant guides. For guided learning this may be an agenda of topics covered in a workshop/training session and links to those resources.
+
+### Next steps
+
+Links to areas this is a pre-req for, other elements in a series, or other topics.
+
+Further resources
+----------------------------
+
+Links to other resources, and what they're useful for explaining.
+May or may not be materials that extend directly from the course

--- a/training/services/CORE_APPS.md
+++ b/training/services/CORE_APPS.md
@@ -1,0 +1,27 @@
+Web & Publishing Journeys
+===========================
+
+The core function of Digital Publishing is to provide a means to prepare, publish and disseminate statistical outputs and analysis content. This requires a Content Management System, used by ONS staff to prepare publications, and a public website for users to access our content. Understanding the services underpinning these journeys is crucial to understanding the service we build and support.
+
+### Pre-reading
+
+For wider context on where Digital Publishing fits in to government statistical production, you may wish to [read this module](culture-and-process/DIGITAL_PUBLISHING.md) first.
+
+### Prerequisites
+
+Explore [ONS.gov.uk](ONS.gov.uk) a bit to get a sense of the kind of information on our website, and ask a member of the team to give you a brief demo of Florence - our content management system. This may help give you some context as we explain the services and architecture that allow all of that to work.
+
+### Materials
+
+[This presentation](https://docs.google.com/presentation/d/1EVacZxrSDmfmwsVSHc9rPBspohRh_MP_eD65Qcpbtm8/edit#slide=id.p) introduces the principles underpinning the way the website was originally constructed, highlighting some core service names and areas we're looking to move beyond. It will explain terms like 'zebedee', 'florence', 'the train', 'babbage' and 'files on disk'. 
+
+### Next steps
+
+To understand how we're moving from these core services to a more maintainable approach, refer to the slides in our [Microservice training](../architecture/MICROSERVICES.md).
+
+
+Further resources
+----------------------------
+
+Links to other resources, and what they're useful for explaining.
+May or may not be materials that extend directly from the course


### PR DESCRIPTION
### What

* Tidied up slides and added training modules for main web & publishing journeys
* Added modules for:
    * API architecture
    * microservice architecture
* Added a WIP CMD training module so the slides link is there for reference at least
* Added keywords to represent need for Packer/Ansible training module ahead of AMI work

### How to review

Do the docs make sense, cover the relevant content, and do the links resolve?

### Who can review

anyone
