### PR TITLE
Update technology stack list

### DIFF
--- a/guides/INSTALLING.md
+++ b/guides/INSTALLING.md
@@ -42,7 +42,7 @@ Software | Install | Notes
     - MongoDB
     - Elasticsearch 6 (on non-standard port)
     - Kafka (plus required Zookeeper dependency)
-    - Neo4J (currently being replaced by [Neptune](https://github.com/ONSdigital/dp/blob/main/guides/NEPTUNE.md#migrating-from-neo4j-to-aws-neptune))
+    - [Neptune](https://github.com/ONSdigital/dp/blob/main/guides/NEPTUNE.md#migrating-from-neo4j-to-aws-neptune))
 
 Return to the [Getting Started](https://github.com/ONSdigital/dp/blob/main/guides/GETTING_STARTED.md) guide for next steps.
 
@@ -151,8 +151,9 @@ All the services in the [web] and [publishing] journeys, as well as:
   git clone git@github.com:ONSdigital/dp-publishing-dataset-controller
   ```
 
-[See more documentation of the import process](https://github.com/ONSdigital/dp-import#dp-import)
-[See sequence diagram of cmd import process](https://github.com/ONSdigital/dp-import/tree/main/docs/import-sequence#readme)
+[Documentation of the import process](https://github.com/ONSdigital/dp-import#dp-import)
+
+[Sequence diagram of cmd import process](https://github.com/ONSdigital/dp-import/tree/main/docs/import-sequence#readme)
 
 #### Cantabular import services:
 

--- a/guides/INSTALLING.md
+++ b/guides/INSTALLING.md
@@ -35,11 +35,12 @@ Software | Install | Notes
 [dp-compose](https://github.com/ONSdigital/dp-compose) runs the following services:
   - Services for Web
     - Elasticsearch 2.4.2
+    - Elasticsearch 7 (on non-standard port)
     - Highcharts
     - Postgres
   - Services for CMD
     - MongoDB
-    - Elasticsearch 5 (on non-standard port)
+    - Elasticsearch 6 (on non-standard port)
     - Kafka (plus required Zookeeper dependency)
     - Neo4J (currently being replaced by [Neptune](https://github.com/ONSdigital/dp/blob/main/guides/NEPTUNE.md#migrating-from-neo4j-to-aws-neptune))
 
@@ -149,6 +150,9 @@ All the services in the [web] and [publishing] journeys, as well as:
   git clone git@github.com:ONSdigital/dp-dimension-search-builder
   git clone git@github.com:ONSdigital/dp-publishing-dataset-controller
   ```
+
+[See more documentation of the import process](https://github.com/ONSdigital/dp-import#dp-import)
+[See sequence diagram of cmd import process](https://github.com/ONSdigital/dp-import/tree/main/docs/import-sequence#readme)
 
 #### Cantabular import services:
 

--- a/guides/TECHNOLOGIES.md
+++ b/guides/TECHNOLOGIES.md
@@ -32,12 +32,18 @@ This is a partially-complete list of technologies used by Digital Publishing.
   * [Java](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
   * [Python](https://www.python.org/)
 * Data
-  * [ElasticSearch](https://www.elastic.co/)
+  * Distributed open search and analytics engine
+    * Local - [ElasticSearch](https://www.elastic.co/)
+    * Hosted environments - [AWS Elasticsearch](https://aws.amazon.com/elasticsearch-service/)
   * [PostgreSQL](https://www.postgresql.org/)
-  * [MongoDB](https://www.mongodb.com/)
-  * [Neo4j](https://neo4j.com/)
-  * [Neptune](https://aws.amazon.com/neptune/)
-  * [Kafka](https://kafka.apache.org/)
+  * NoSQL Database
+    * Local - [MongoDB](https://www.mongodb.com/)
+    * Hosted environments - [AWS Document DB](https://aws.amazon.com/documentdb/)
+  *  Graph NoSQL Database
+     * Local & hosted environments - [AWS Neptune](https://aws.amazon.com/neptune/)
+  * Distributed event streaming platform
+    * Local - [Kafka](https://kafka.apache.org/)
+    * Hosted environments - [AWS MSK](https://aws.amazon.com/msk/)
 * Documentation Tools
   * [DapperDox](http://dapperdox.io/)
 * Build tools
@@ -53,8 +59,9 @@ This is a partially-complete list of technologies used by Digital Publishing.
 * [Pingdom](https://www.pingdom.com/)
 * [CloudFlare](https://www.cloudflare.com/)
 * [Hashicorp](https://www.hashicorp.com/)
-  * [Nomad](https://www.nomadproject.io/)
   * [Consul](https://www.consul.io/)
+  * [Nomad](https://www.nomadproject.io/)
+  * [Packer](https://www.packer.io/)
   * [Vault](https://www.vaultproject.io/)
 * [AWS](https://aws.amazon.com/)
   * [EC2](https://aws.amazon.com/ec2/)
@@ -68,6 +75,10 @@ This is a partially-complete list of technologies used by Digital Publishing.
   * [SQS](https://aws.amazon.com/sqs/)
   * [IAM](https://aws.amazon.com/iam/)
   * [RDS](https://aws.amazon.com/rds/)
+  * [Elasticsearch](https://aws.amazon.com/elasticsearch-service/)
+  * [Document DB](https://aws.amazon.com/documentdb/)
+  * [MSK](https://aws.amazon.com/msk/)
+  * [AWS Neptune](https://aws.amazon.com/neptune/)
 * [ELK Stack](https://www.elastic.co/elk-stack)
   * [Kibana](https://www.elastic.co/products/kibana)
   * [Elasticsearch](https://www.elastic.co/products/elasticsearch)

--- a/guides/TECHNOLOGIES.md
+++ b/guides/TECHNOLOGIES.md
@@ -78,7 +78,7 @@ This is a partially-complete list of technologies used by Digital Publishing.
   * [Elasticsearch](https://aws.amazon.com/elasticsearch-service/)
   * [Document DB](https://aws.amazon.com/documentdb/)
   * [MSK](https://aws.amazon.com/msk/)
-  * [AWS Neptune](https://aws.amazon.com/neptune/)
+  * [Neptune](https://aws.amazon.com/neptune/)
 * [ELK Stack](https://www.elastic.co/elk-stack)
   * [Kibana](https://www.elastic.co/products/kibana)
   * [Elasticsearch](https://www.elastic.co/products/elasticsearch)


### PR DESCRIPTION
### What

Extend technology stack to include the actual versions of elasticsearch in use. Also include the managed services used in our environments.

Lastly added link to CMD import documentation located in dp-import repo

### How to review

Check changes make sense

### Who can review

Anyone
