### PR TITLE
Update API standards to explain API routers job and core principles

### DIFF
--- a/guides/NEW_API.md
+++ b/guides/NEW_API.md
@@ -1,0 +1,45 @@
+Creating a new API microservice
+==================
+
+The following steps will guide you through adding a new API to our platform.
+
+**NOTE:** For the specifics of getting a new service up and running follow our [new app](NEW_APP.md) guide first, and come back here for the specific *additional* steps required for APIs.
+
+Prerequisites
+-------------
+
+If any of the following Github links 404, likely you need to be added to the ONSdigital organisation.
+
+To follow this guide you will need:
+
+* A Github account with access to the ONSdigital organisation
+
+* The [dp-api-router](https://github.com/ONSdigital/dp-api-router) repo cloned locally
+
+* [dp-configs](https://github.com/ONSdigital/dp-configs) repo cloned locally
+
+* The ['magic port'](https://github.com/ONSdigital/dp-setup/blob/develop/PORTS.md) assigned to your microservice API 
+
+Getting started
+---------------
+
+1. Identify the top level route your API will be responsible for. This likely can be taken from the repository name e.g. dp-dataset-api has the top level route **/datasets**. Make sure it doesn't clash with any existing routes [in the router](https://github.com/ONSdigital/dp-api-router/blob/develop/service/service.go#L126)
+
+2. Add a new API URL variable to the dp-api-router [config.go](https://github.com/ONSdigital/dp-api-router/blob/develop/config/config.go#L19) and set a [default value](https://github.com/ONSdigital/dp-api-router/blob/develop/config/config.go#L71) using the localhost:port combination the app will default to when running locally
+
+3. Update the dp-api-router secrets for relevant environments to contain your new API URL environment variable, listing the ['magic port'](https://github.com/ONSdigital/dp-setup/blob/develop/PORTS.md) instead of the default value.
+
+3. Set up a new API Proxy in [service.go](https://github.com/ONSdigital/dp-api-router/blob/develop/service/service.go#L138), referencing the variable you added to config.go above.
+
+4. Determine where best to add the [handler line](https://github.com/ONSdigital/dp-api-router/blob/develop/service/service.go#L145) - replacing the values for your new API Proxy and the top level route you identified in step 1.
+
+    1. If your API is still in development, you likely want to add it behind a feature flag [as shown by the Observation API](https://github.com/ONSdigital/dp-api-router/blob/develop/service/service.go#L130) so that the route doesn't start to forward in production until you are ready. This will also mean adding an extra feature flag to the config.go file.
+    2. If your API should only be available privately (for use interally/by the publishing system) it should be created [inside the private endpoints list](https://github.com/ONSdigital/dp-api-router/blob/develop/service/service.go#L155). It is acceptable to further control an API behind a feature flag while in development within this section.
+
+5. If some features of your API should only be available internally, update your new service to include a feature flag for 'privateEndpoints' and only attach those routes to your service when enabled [as shown here](https://github.com/ONSdigital/dp-dimension-search-api/blob/develop/api/api.go#L120)
+
+6. Update the secrets for the dp-api-router and your new application to reflect all feature flags your may have added an enable them only in develop while you get your new API ready for production use.
+
+7. Merge your changes to both applications and deploy to develop!
+
+You should now see your API reachable through https://api.develop.onsdigital.co.uk/v1/<your-route>

--- a/guides/NEW_API.md
+++ b/guides/NEW_API.md
@@ -8,7 +8,7 @@ The following steps will guide you through adding a new API to our platform.
 Prerequisites
 -------------
 
-If any of the following Github links 404, likely you need to be added to the ONSdigital organisation.
+If any of the following Github links 404, you will likely need to be added to the ONSdigital organisation.
 
 To follow this guide you will need:
 
@@ -25,9 +25,9 @@ Getting started
 
 1. Identify the top level route your API will be responsible for. This likely can be taken from the repository name e.g. dp-dataset-api has the top level route **/datasets**. Make sure it doesn't clash with any existing routes [in the router](https://github.com/ONSdigital/dp-api-router/blob/develop/service/service.go#L126)
 
-2. Add a new API URL variable to the dp-api-router [config.go](https://github.com/ONSdigital/dp-api-router/blob/develop/config/config.go#L19) and set a [default value](https://github.com/ONSdigital/dp-api-router/blob/develop/config/config.go#L71) using the localhost:port combination the app will default to when running locally
+2. Add a new API URL variable to the dp-api-router [config.go](https://github.com/ONSdigital/dp-api-router/blob/develop/config/config.go#L19) and set a [default value](https://github.com/ONSdigital/dp-api-router/blob/develop/config/config.go#L71) using the localhost:port combination the app will default to when running locally. The default ports [should be documented](https://github.com/ONSdigital/dp/blob/main/guides/PORTS.md) if not already.
 
-3. Update the dp-api-router secrets for relevant environments to contain your new API URL environment variable, listing the ['magic port'](https://github.com/ONSdigital/dp-setup/blob/develop/PORTS.md) instead of the default value.
+3. Update the dp-api-router [secrets for relevant environments](https://github.com/ONSdigital/dp-configs/tree/master/secrets) to contain your new API URL environment variable, listing the ['magic port'](https://github.com/ONSdigital/dp-setup/blob/develop/PORTS.md) instead of the default value.
 
 3. Set up a new API Proxy in [service.go](https://github.com/ONSdigital/dp-api-router/blob/develop/service/service.go#L138), referencing the variable you added to config.go above.
 
@@ -38,7 +38,7 @@ Getting started
 
 5. If some features of your API should only be available internally, update your new service to include a feature flag for 'privateEndpoints' and only attach those routes to your service when enabled [as shown here](https://github.com/ONSdigital/dp-dimension-search-api/blob/develop/api/api.go#L120)
 
-6. Update the secrets for the dp-api-router and your new application to reflect all feature flags your may have added an enable them only in develop while you get your new API ready for production use.
+6. Update the [secrets](https://github.com/ONSdigital/dp-configs/tree/master/secrets) for the dp-api-router and your new application to reflect all feature flags your may have added an enable them only in develop while you get your new API ready for production use.
 
 7. Merge your changes to both applications and deploy to develop!
 

--- a/standards/API_STANDARDS.md
+++ b/standards/API_STANDARDS.md
@@ -1,53 +1,48 @@
 API standards
 =============
 
-### Fields
+## Core Principles
+
+We use APIs to represent our data in machine-readable, predictable ways.
+
+Our APIs follow [RESTful principles](https://restfulapi.net/) which are worth understanding more fully but highlights we're particularly focussed on are:
+- Endpoints must return JSON responses and correct/meaningful HTTP status codes
+- Endpoints must use appropriate requests methods (GET/PUT/POST etc). Changes must not be made via GET requests.
+- Concrete path elements must be pluralised e.g. datasets not dataset in /datasets/<id>
+- Endpoints must be documented using the Swagger/OpenAPI standard
+- Updates to data must be idempotent
+
+More details of precise behaviour we expect including guidance on field names, timestamps, pagination and responses are given below.
+
+## Our API Landscape
+
+Our [API training](../training/architecture/API.md) lays this out in more detail, but in order to allow each microservice API to focus on managing its data well some behaviour has been abstracted from the API services. This behaviour instead sits at the [API router](https://github.com/ONSdigital/dp-api-router).
+
+Every request coming in on our api.ons.gov.uk domain must pass through our API router, which will perform a number of common checks and then determine which microservice to route traffic through to. When this API router is running internally, these checks include checking for relevant authentication headers and ensuring the request is audited for security reasons.
+
+All API requests must travel through the API router, including app-to-app traffic. This is referred to as 'eating our own dog food' in our [Architecture Standards](ARCHITECTURE_STANDARDS.md). Not only does this ensure that all internal traffic is subject to the same security checks, it serves as quality assurance that our APIs are usable.
+
+We use feature flags to limit what behaviour is available on our public facing API microservices. Typically, only GET endpoints are exposed on public APIs, though user transaction services such as filter and flex data journeys are an exception to this.
+
+To add a new API microservice [follow our guide](../guides/NEW_API.md) to ensure the API router is updated correctly.
+
+## API Structure and Syntax
+
+### Syntax & types
 
   * Field names snake case, e.g. `total_count`
   * Use appropriate types for fields, e.g. numbers should be ints not strings
-  * Resource IDs should use GUIDs not auto-incrementing counts
   * Timestamps should be UTC (optionally, with a timezone)
-  * Use the `GET` method for search endpoints
-  * Search/list endpoints should contain consistent fields:
-    * Response: `count`, `limit`, `offset`, `total_count`
+  * Root endpoint IDs should always be referred to as `id`, rather than name-spaced. All IDs under this level will need descriptive placeholder names. e.g. /datasets/<id>/editions/<edition> where /datasets is the root endpoint
 
-	  When pagination is required, it is also required the data be in a sorted order before it can be paginated. The fields work as:
+### Methods & Behaviours
+ * Use the `GET` method for search endpoints
+ * `POST` endpoints should typically generate IDs, and these should use GUIDs not auto-incrementing counts
 
-	  `limit` - max number of items we're returning in this response.
-	  * If value is not set, a configurable default limit should be used, unless otherwise stated this should be set to a value of `20`.
-	  * The limit value can be set to `0` to return `0` items, so an API user can obtain the metadata for the list endpoint.
-
-	  `count` - how many items are actually present in the response.
-
-	  `total_count` - how many total items there may be (so the full list size, maybe thousands).
-
-	  `offset` - the number of documents into the full list that this particular response is starting at, this should default to `0` if not set. 
-
-	  *For example, in a list that has a total_count of 511, we might set a limit of 100, an offset of 500, and get a response whose count is 11, because it's the last 11 documents in the list.*
-	  
-	  `items` - array containing results. 
-	    * Should only return items which match the offset and limit criteria, e.g. using the example above, you would expect the items array to only contain 11 documents.
-
-    * Maximum Defaults to help protect the service from performance problems due to allowing large limit and offset query values being set: `DEFAULT_MAXIMUM_LIMIT`, `DEFAULT_MAXIMUM_OFFSET`
-
-	  `DEFAULT_MAXIMUM_LIMIT` - Environment variable to cap the number of items to be returned.
-	  * Should be set in the region of 500 to 1000 items. It is good practice to return a few results at a time, so requests don’t tie up resources for too long by trying to get all the requested data at once.
-	  * Should return 400 (bad request) status code and an error explaining the maximum limit on limit value and providing the maximum value.
-
-	  `DEFAULT_MAXIMUM_OFFSET` - **Optional** environment variable to cap how far one can access a list of items.
-	  * This is optional and is dependent on the underlying database. *Example an API relying on Elasticsearch will need a maximum offset value see why in the [example below](#elasticsearch-example-of-performance-issues-using-large-offsets).*
-	  * Should return 400 (bad request) status code and an error explaining the maximum limit on offset value and providing the maximum value.
-
-
-#### Elasticsearch example of performance issues using large offsets
-
-An API accepting large offset values to paginate data returned from elasticsearch will result in slow responses. This is due to data being spread across multiple shards in an Elasticsearch cluster.
-
-The processing in Elasticsearch requires it to sort the data on each shard based on the request (search query) and store the requested hits and hits for previous pages into memory; then accumulate all the information from each shard to work out the actual hits (search document) to return. This gets more resource intensive as one pages deeper and can result in slower responses between the requesing service (API) to Elasticsearch, [to read more on Elasticsearch pagination here](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#paginate-search-results).
-
-### Links
+ ### Links
+* All endpoints must return a `links.self` subdoc in their response,
 * Resources should avoid a nested list by having a links to list endpoints
-* Links should be fully qualified URLs
+* Responses must contain fully qualified URLs, though this may be managed by the API router
 * `Links` object contains descriptively named objects which each contain
   an `id` (optional) and `url` field e.g.
   ```
@@ -65,6 +60,10 @@ The processing in Elasticsearch requires it to sort the data on each shard based
           },
           "subresources":{
               "url":"/thisapi/1234/subresources"
+          },
+          "self":{
+              "id":"1234",
+              "url":"/thisapi/1234"
           }
       }
   }
@@ -74,19 +73,48 @@ The processing in Elasticsearch requires it to sort the data on each shard based
   to contain links to all higher elements e.g. the resource at
   `/datasets/1234/editions/2345/versions/1` would contain a link to
   `/datasets/1234/editions/2345` but not to `/datasets/1234`
-  
-### Spec
-  * Placeholder names
-      * Root endpoint IDs should always be referred to as `id`, rather than
-        name-spaced. All IDs under this level will need descriptive placeholder
-        names.
-  * Concrete path elements should be plural words e.g. /**datasets**/{id} or /**animals**
 
 
-### Responses
-  * Use appropriate HTTP status codes
+### Returning errors
   * **Errors** should return a status code and a JSON payload with the error message
       * `errors` array containing error messages
+
+
+### Returning lists or search results
+Search/list endpoints should contain the following fields: `count`, `limit`, `offset`, `total_count`, `items`
+
+The fields work as:
+
+* `limit` - max number of items we're returning in this response.
+    * If value is not set, a configurable default limit should be used, unless otherwise stated this should be set to a value of `20`.
+    * The limit value can be set to `0` to return `0` items, so an API user can obtain the metadata for the list endpoint.
+
+* `count` - how many items are actually present in the response.
+
+* `total_count` - how many total items there may be (so the full list size, maybe thousands).
+
+* `offset` - the number of documents into the full list that this particular response is starting at, this should default to `0` if not set. 
+    * For example, in a list that has a total_count of 511, we might set a limit of 100, an offset of 500, and get a response whose count is 11, because it's the last 11 documents in the list.*
+	  
+* `items` - array containing results. 
+    * Should only return items which match the offset and limit criteria, e.g. using the example above, you would expect the items array to only contain 11 documents.
+	  
+When pagination is required, it is also required the data be in a sorted order before it can be paginated. We should always configure defaults to help protect the service from performance problems due to allowing large limit and offset query values being set: `DEFAULT_MAXIMUM_LIMIT`, `DEFAULT_MAXIMUM_OFFSET`
+
+* `DEFAULT_MAXIMUM_LIMIT` - Environment variable to cap the number of items to be returned.
+	  * Should be set in the region of 500 to 1000 items. It is good practice to return a few results at a time, so requests don’t tie up resources for too long by trying to get all the requested data at once.
+	  * Should return 400 (bad request) status code and an error explaining the maximum limit on limit value and providing the maximum value.
+
+* `DEFAULT_MAXIMUM_OFFSET` - **Optional** environment variable to cap how far one can access a list of items.
+	  * This is optional and is dependent on the underlying database. *Example an API relying on Elasticsearch will need a maximum offset value see why in the [example below](#elasticsearch-example-of-performance-issues-using-large-offsets).*
+	  * Should return 400 (bad request) status code and an error explaining the maximum limit on offset value and providing the maximum value.
+
+
+#### Elasticsearch example of performance issues using large offsets
+
+An API accepting large offset values to paginate data returned from elasticsearch will result in slow responses. This is due to data being spread across multiple shards in an Elasticsearch cluster.
+
+The processing in Elasticsearch requires it to sort the data on each shard based on the request (search query) and store the requested hits and hits for previous pages into memory; then accumulate all the information from each shard to work out the actual hits (search document) to return. This gets more resource intensive as one pages deeper and can result in slower responses between the requesing service (API) to Elasticsearch, [to read more on Elasticsearch pagination here](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#paginate-search-results).
 
 
 #### TODO


### PR DESCRIPTION
### What

Updated API standards to start a bit more from 0 instead of 60 on existing understanding.
- Included mention of RESTful principles
- Included explanation of the role of the API router
- Tidied up existing standards around fields and conventions

Also added a guide for adding a new API, to highlight changes needed in API router

### How to review

Check it all makes sense and nothing is missing
Check links work

### Who can review

Anyone
