### PR TITLE
Feature/update documentation

### DIFF
--- a/guides/AWS_ACCOUNT_ACCESS.md
+++ b/guides/AWS_ACCOUNT_ACCESS.md
@@ -35,6 +35,8 @@ Follow the guide at [Configuring the AWS CLI](https://docs.aws.amazon.com/cli/la
   SSO Region: eu-west-2
 ```
 
+N.B. follow instructions for the _"Legacy non-refreshable configuration"_. Creating sso-session names will cause a `SSOProviderInvalidToken: the SSO session has expired or is invalid` error for `dp-cli`.
+
 Each environment you have access to will need to be configured. Make sure you name each profile the same as the environment (dp-sandbox, dp-staging, dp-prod, dp-ci) so that it works seamlessly with other DP tooling (dp-cli, terraform). A sample config is included at the end of this guide as a reference.
 
 ## Sample config for `~/.aws/config`:

--- a/training/architecture/API.md
+++ b/training/architecture/API.md
@@ -9,7 +9,7 @@ Understand our [microservice](MICROSERVICES.md) approach
 
 ### Materials
 
-[This presentation](https://docs.google.com/presentation/d/1K7NN-oPn427Xc339s6NL3vbfNGPC62y3euhvRapwFf8/edit#slide=id.p) gives a basic introduction to what our API service is providing, why we care to make our APIs public and how we break down our microservices when it comes to API development. It also outlines some initial plans for API development required for Census work.
+[This presentation](https://docs.google.com/presentation/d/1FEGQm2LaIlCAQhYG7Sp2PSWmCuZjXy_W/edit#slide=id.p1) gives a basic introduction to what our API service is providing, why we care to make our APIs public and how we break down our microservices when it comes to API development. It also outlines some initial plans for API development required for Census work.
 
 Our [API standards](https://github.com/ONSdigital/dp-standards/blob/main/API_STANDARDS.md#api-standards) are also an important read to understand the full context needed to begin API development in our context.
 

--- a/training/architecture/DATA_TERMS.md
+++ b/training/architecture/DATA_TERMS.md
@@ -65,5 +65,5 @@ None.
 
 Further resources
 ----------------------------
-- The CSV file format used in the Customise my Data systems is known as a **V4** file, and is [further defined here](https://docs.google.com/document/d/1szyhfZZYO3c5-jeMVrXOJha5JCltCDYZC2ySNcruNOc/edit)
+- The CSV file format used in the Customise my Data systems is known as a **V4** file, and is [further defined here](https://docs.google.com/document/d/1NapvpK6pD0vSI5lIOJUkfkvjw8_ryZ8t/edit)
 - Look at the 'Terminology' section on the [Developer Site](https://developer.ons.gov.uk/) for another take on some of these terms.

--- a/training/architecture/MICROSERVICES.md
+++ b/training/architecture/MICROSERVICES.md
@@ -14,7 +14,7 @@ Understand a [basic definition of microservices](https://smartbear.com/solutions
 
 ### Materials
 
-[This presentation](https://docs.google.com/presentation/d/1bXZw2rJTBa7spXVQNuA0lVQSN-2jZiz9khn6hJsvWwc/edit#slide=id.ge2b2dc2785_0_359) walks through our different service types and where they are commonly deployed. It also highlights some considerations and standards that are common across all of our service types, such as healthchecking.
+[This presentation](https://docs.google.com/presentation/d/1gL9lzOAN4JycdGqYsNslykuYedviQnc_/edit#slide=id.p1) walks through our different service types and where they are commonly deployed. It also highlights some considerations and standards that are common across all of our service types, such as healthchecking.
 
 As microservices mean we often have to create new repositories, we have created a [project generation](https://github.com/ONSdigital/dp-cli/tree/main/project_generation) tool that allows us to start from a boilerplated version of the relevant kind of repository. We also have a [hello world](https://github.com/ONSdigital/dp-hello-world) repo where we document our baseline application structure for reference, review, and as a place to center conversations about standards.
 

--- a/training/culture-and-process/70_20_10_TIME.md
+++ b/training/culture-and-process/70_20_10_TIME.md
@@ -4,7 +4,7 @@
 As part of working in Digital Publishing, the development team share sprint time between the following:
 - 70% - feature work driven by product managers
 - 20% - technical workflows and tools driven by technical leads and development teams
-- 10% - personal development driven by a developer, their piers and/or manager
+- 10% - personal development driven by a developer, their peers and/or manager
 
 ### Pre-reading
 
@@ -35,7 +35,7 @@ Some things that are covered in 20% time work includes:
 
 This could include developing leadership, mentoring and inclusivity skills or learn/upskill in a technology or development practices to improve technical skillset. Other options here would be to build a prototype to solve a problem for the development team or wider development community.
 
-There is a "dev-10-pc-time" slack channel available to post any learnings or progression of prototypes to share with the wider team as well as share ideas and to collaboration with your piers - it is not mandatory to post in this slack channel when doing any personal development.
+There is a "dev-10-pc-time" slack channel available to post any learnings or progression of prototypes to share with the wider team as well as share ideas and to collaboration with your peers - it is not mandatory to post in this slack channel when doing any personal development.
 
 Caveats to 10% time are as follows:
 - New starters who have been given a training project will not do 10% time (as this is their training), generally the case for HEO and EO starters.

--- a/training/culture-and-process/CICD.md
+++ b/training/culture-and-process/CICD.md
@@ -51,7 +51,7 @@ A more comprehensive look at how CI/CD works at ONS Digital Publishing can be fo
 
 This section is a continuation of the steps outlined in the "Ready for Release" section [here](TRELLO_BOARD_FLOW.md). 
 
-1. To deploy an app, you will need to have logged into ONS Digital Councourse via the link above. You can log in via your personal Github account, or email addresss
+1. To deploy an app, you will need to have logged into ONS Digital Concourse via the link above. You can log in via your personal Github account, or email addresss
 2. Once logged into Concourse, you should see the all of the pipelines that are currently running 
 3. Find the correct pipeline for the repository you are releasing to. So, for example, if you have created a release for `dp-dataset-api`, you will need to find the corresponding pipeline. In this case it would be - https://concourse.onsdigital.co.uk/teams/main/pipelines/dp-dataset-api
 4. If you have followed previous steps in the "Ready for Release" section linked above, and the changes have been pushed to the `master` branch, Concourse should start the build. You will see that the build has started running as it will be indicated by a yellow border.

--- a/training/culture-and-process/GITFLOW.md
+++ b/training/culture-and-process/GITFLOW.md
@@ -3,21 +3,22 @@ Gitflow
 
 A useful resource outlining Gitflow can be found [here](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow). This should provide a good understaning of the Gitflow model.
 
+The below will use the term `main` for the live branch - some repositories may still use the legacy term `master`.
+
 ## What is Gitflow?
 
 Gitflow is essentially a branching model of Git, and the model used at ONS Digital.
 
 It allows developers to manage source code for regular releases, and provides a framework for developers to be able to work on features separately from one another without any unwanted clashes.
 
-At its basic level, the Gitflow model will use two permanent branches - `master` and `develop`. The `master` branch is used for the production code, and the `develop` branch is used to check code before going to `master`.
+At its basic level, the Gitflow model will use two permanent branches - `main` and `develop`. The `main` branch is used for the production code, and the `develop` branch is used to check code before going to `main`.
 
-Each of the features developers are working on also get their own branch. Usually they will branch off from `develop`, not from `master` (however, in some cases this may not be true, and `feature` branches come directly from the `master` branch). Once the the work on the feature is done, it is then merged into `develop`.
-
+Each of the features developers are working on also get their own branch. Usually they will branch off from `develop`, not from `main` (however, in some cases this may not be true, and `feature` branches come directly from the `main` branch). Once the the work on the feature is done, it is then merged into `develop`.
 
 ## Gitflow Branches
 
+### Main
 
-### Master
 This is the live branch of the project and contains the last release version of source code in production.
 
 ### Develop
@@ -30,4 +31,4 @@ Feature branches are used to develop new features for the upcoming release. The 
 
 ### Release
 
-Release branches support preparation of a new production release. Creating this branch starts the next release cycle. Once it's ready to ship, the `release` branch gets merged into `master` and tagged with a version number. See [here](https://github.com/ONSdigital/dp/blob/main/guides/VERSIONING.md) for more information on version control at ONS Digital.
+Release branches support preparation of a new production release. Creating this branch starts the next release cycle. Once it's ready to ship, the `release` branch gets merged into `main` and tagged with a version number. See [here](https://github.com/ONSdigital/dp/blob/main/guides/VERSIONING.md) for more information on version control at ONS Digital.

--- a/training/culture-and-process/PULL_REQUEST_GUIDANCE.md
+++ b/training/culture-and-process/PULL_REQUEST_GUIDANCE.md
@@ -5,7 +5,7 @@ General guidance on creating a pull request
 ## Pre-reading
 
 - It is useful to have [an understanding of GIT](https://git-scm.com/about) and branches as a way of working
-- Have a look at pull requests in the `#dev-code-review` channel on Slack
+- Have a look at pull requests in the `#dev_code_review` channel on Slack
 - There is also this documentation on our [contributing guidelines](https://github.com/ONSdigital/dp/blob/main/guides/CONTRIBUTING.md#development-work) which covers some aspects of creating pull requests.
 - There is also an option to create a *draft* pull request, these can be created to have a discussion about a feature before it is ready for a code review.
 

--- a/training/services/CMD.md
+++ b/training/services/CMD.md
@@ -14,7 +14,7 @@ Need to do before doing this course. None if not needed.
 ### Materials
 
 TODO:
-* :warning: [These slides](https://docs.google.com/presentation/d/1bXZw2rJTBa7spXVQNuA0lVQSN-2jZiz9khn6hJsvWwc/edit#slide=id.ge3df80403a_0_0) need updating
+* :warning: [These slides](https://docs.google.com/presentation/d/1gL9lzOAN4JycdGqYsNslykuYedviQnc_/edit#slide=id.p9) need updating
 * provide links to explore the journey
 
 Module content or link to it. For self-learning this may be a text explanation of an area with links to a few relevant guides. For guided learning this may be an agenda of topics covered in a workshop/training session and links to those resources.

--- a/training/services/CORE_APPS.md
+++ b/training/services/CORE_APPS.md
@@ -13,7 +13,7 @@ Explore [ONS.gov.uk](ONS.gov.uk) a bit to get a sense of the kind of information
 
 ### Materials
 
-[This presentation](https://docs.google.com/presentation/d/1EVacZxrSDmfmwsVSHc9rPBspohRh_MP_eD65Qcpbtm8/edit#slide=id.p) introduces the principles underpinning the way the website was originally constructed, highlighting some core service names and areas we're looking to move beyond. It will explain terms like 'zebedee', 'florence', 'the train', 'babbage' and 'files on disk'. 
+[This presentation](https://docs.google.com/presentation/d/1tYEmddv2icKKmFkrSTMbiMPUE53pbbRA/edit#slide=id.p1) introduces the principles underpinning the way the website was originally constructed, highlighting some core service names and areas we're looking to move beyond. It will explain terms like 'zebedee', 'florence', 'the train', 'babbage' and 'files on disk'.
 
 ### Next steps
 

--- a/training/services/INFRASTRUCTURE.md
+++ b/training/services/INFRASTRUCTURE.md
@@ -29,7 +29,7 @@ You should be given relevant AWS accounts by your manager, or a Tech Lead - spea
 
 ### Materials
 - [AWS Overview](https://docs.aws.amazon.com/whitepapers/latest/aws-overview/introduction.html)
-- The workshop will walk through the [Digital Publishing 101: Basic Infrastructure slides (WIP)](https://docs.google.com/presentation/d/1VQjYd6R6xDRluA_fTF4teu97umJam2y--XlewZjeBrU/edit?usp=sharing) over roughly 1 hour, with time for questions.
+- The workshop will walk through the [Digital Publishing 101: Basic Infrastructure slides (WIP)](https://docs.google.com/presentation/d/1w9A2Wn3S6JH4oqApfBLhKVco4QVVJ-wk/edit#slide=id.p1) over roughly 1 hour, with time for questions.
 
 ### Next steps
 


### PR DESCRIPTION
### What

Updated some documentation:

- Links to old gdrive
- Typos
- Old slack channel link
- Updated gitflow doc to reflect 'main' branch instead of 'master'
- Added note on AWS config to follow legacy instruction <-- this might be wrong, but certainly allowed mine to work. 

### How to review

Check the changes are accurate and make sense. 

### Who can review

Another developer. 