### PR TITLE
Remove the Articles API port from the list

### DIFF
--- a/guides/PORTS.md
+++ b/guides/PORTS.md
@@ -94,7 +94,6 @@ in development without having to configure them individually.
 | 26700 | [dp-cantabular-metadata-exporter](https://github.com/ONSdigital/dp-cantabular-metadata-exporter) |
 | 26800 | [dp-cantabular-xlsx-exporter](https://github.com/ONSdigital/dp-cantabular-xlsx-exporter) |
 | 26900 | [dp-files-api](https://github.com/ONSdigital/dp-files-api) |
-| 27000 | [dp-articles-api](https://github.com/ONSdigital/dp-articles-api) |
 | 27017 | [dp-compose](https://github.com/ONSdigital/dp-compose) : mongo |
 | 27100 | [dp-cantabular-filter-flex-api](https://github.com/ONSdigital/dp-cantabular-filter-flex-api) |
 | 27200 | [dp-cantabular-dimension-api](https://github.com/ONSdigital/dp-cantabular-dimension-api) |


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
The port number of the dp-articles-api has been removed as that service is not needed for the foreseeable future. This work is for the following ticket:

```shell
https://trello.com/c/rzIQoHXj/1383-make-articles-api-read-only
```

# How to review
<!--- Describe in detail how you tested your changes. -->
Check that the correct service's port has been deleted.

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
