### PR TITLE
Add a new port for dp-legacy-cache-api and update the New App documentation

### DIFF
--- a/guides/NEW_APP.md
+++ b/guides/NEW_APP.md
@@ -10,9 +10,9 @@ Prerequisites
 
 To follow this guide you will need:
 
-* A Github account with access to the ONSdigital organisation
+* A GitHub account with access to the ONSdigital organisation
 
-* A login for the concourse CI environment
+* A login for the Concourse CI environment
 
 * [dp-cli](https://github.com/ONSdigital/dp-cli)
 
@@ -20,22 +20,18 @@ To follow this guide you will need:
 
   `$ brew install git`
 
-* Terraform, in document `dp-setup/terraform/README.md` install the version specified in the Prerequisites section : [dp-setup](https://github.com/ONSdigital/dp-setup/blob/develop/terraform/README.md#prerequisites) 
+* Terraform: follow the instructions in the [Terraform's Prerequisites section of dp-setup](https://github.com/ONSdigital/dp-setup/blob/awsb/terraform/README.md#prerequisites) to install the specified version. Do not install Terraform directly from Homebrew, as it will install the latest version by default
 
-  If for example that specifies version 0.13, then do:
-  
-  `$ brew install terraform@0.13`
-
-* Fly CLI (can be downloaded from the links in the corner of the concourse UI)
+* Fly CLI (can be downloaded from the links in the corner of the Concourse UI)
 
 Getting started
 ---------------
 
-These steps will create a new app that is built by CI and deployed to the develop and production environments.  If any of the following Github links 404, likely you need to be added to the ONSdigital organisation.
+These steps will create a new app that is built by CI and deployed to the develop and production environments. If any of the following GitHub links 404, likely you need to be added to the ONSdigital organisation.
 
 1. Determine what language and technologies you will use
 1. Pick a local dev port for your app and add it to the [local ports list](PORTS.md)
 1. Use [`dp-cli` to generate the new repo with boilerplate files](https://github.com/ONSdigital/dp-cli/tree/main/project_generation/COMPLETE_PROJECT_SETUP.md)
 1. [Add the new app to the environment](https://github.com/ONSdigital/dp-setup#adding-a-new-app)
-1. [Add configurations for your new app](https://github.com/ONSdigital/dp-configs#adding-a-new-app) *Note: The Concourse CI pipeline `pipeline-generator` will auto-generate the pipeline for the new app.*
-2. Check the [Concourse UI](https://github.com/ONSdigital/dp/blob/main/training/platform-services/PLATFORM.md#concourse) and/or [Nomad UI](https://github.com/ONSdigital/dp/blob/main/training/platform-services/PLATFORM.md#nomad) to ensure your new app has successfully deployed to develop. See [here](https://github.com/ONSdigital/dp-setup/tree/develop/scripts#ansible-vault-helpers) for info on getting any acl tokens.
+1. [Add configurations for your new app](https://github.com/ONSdigital/dp-configs#adding-a-new-app). *Note: The Concourse CI pipeline `pipeline-generator` will auto-generate the pipeline for the new app*
+1. Check the [Concourse UI](https://github.com/ONSdigital/dp/blob/main/training/platform-services/PLATFORM.md#concourse) and/or [Nomad UI](https://github.com/ONSdigital/dp/blob/main/training/platform-services/PLATFORM.md#nomad) to ensure your new app has successfully deployed to develop. See [here](https://github.com/ONSdigital/dp-setup/tree/develop/scripts#ansible-vault-helpers) for info on getting any acl tokens

--- a/guides/PORTS.md
+++ b/guides/PORTS.md
@@ -28,10 +28,10 @@ in development without having to configure them individually.
 | 9200  | [dp-compose](https://github.com/ONSdigital/dp-compose) : elasticsearch |
 | 9300  | [dp-compose](https://github.com/ONSdigital/dp-compose) : elasticsearch |
 | 9999  | [dp-compose](https://github.com/ONSdigital/dp-compose) : highcharts |
-| 10200  | [dp-compose](https://github.com/ONSdigital/dp-compose) : cmd elasticsearch |
-| 10300  | [dp-compose](https://github.com/ONSdigital/dp-compose) : cmd elasticsearch |
-| 11200  | [dp-compose](https://github.com/ONSdigital/dp-compose) : site wide elasticsearch |
-| 11300  | [dp-compose](https://github.com/ONSdigital/dp-compose) : site wide elasticsearch |
+| 10200 | [dp-compose](https://github.com/ONSdigital/dp-compose) : cmd elasticsearch |
+| 10300 | [dp-compose](https://github.com/ONSdigital/dp-compose) : cmd elasticsearch |
+| 11200 | [dp-compose](https://github.com/ONSdigital/dp-compose) : site wide elasticsearch |
+| 11300 | [dp-compose](https://github.com/ONSdigital/dp-compose) : site wide elasticsearch |
 | 20000 | [dp-frontend-router](https://github.com/ONSdigital/dp-frontend-router) |
 | 20001 | [dp-frontend-filter-dataset-controller](https://github.com/ONSdigital/dp-frontend-filter-dataset-controller)
 | 20010 | [dp-frontend-renderer](https://github.com/ONSdigital/dp-frontend-renderer) |
@@ -111,3 +111,4 @@ in development without having to configure them individually.
 | 28800 | [dp-nlp-category-api](https://github.com/ONSdigital/dp-nlp-category-api) |
 | 28900 | [dp-nlp-berlin-api](https://github.com/ONSdigital/dp-nlp-berlin-api) |
 | 29000 | [dp-cpih-export](https://github.com/ONSdigital/dp-cpih-export) |
+| 29100 | [dp-legacy-cache-api](https://github.com/ONSdigital/dp-legacy-cache-api) |


### PR DESCRIPTION
### What

- Added a new port for `dp-legacy-cache-api`.
- Updated the New App documentation as it had some out of date or inaccurate data.

### How to review

- Check that the new port does not clash with other existing ports.
- Ensure that the documentation for the New App is correct.

### Who can review

Anyone at ONS.
