### PR TITLE
remove port for dp-frontend-geogrpahy-controller

### DIFF
--- a/guides/PORTS.md
+++ b/guides/PORTS.md
@@ -62,7 +62,6 @@ in development without having to configure them individually.
 | 23400 | [dp-file-downloader](https://github.com/ONSdigital/dp-file-downloader) |
 | 23500 | [dp-map-renderer](https://github.com/ONSdigital/dp-map-renderer) |
 | 23600 | [dp-developer-site](http://github.com/ONSdigital/dp-developer-site) |
-| 23700 | [dp-frontend-geography-controller](https://github.com/ONSdigital/dp-frontend-geography-controller) |
 | 23900 | [dp-search-api](https://github.com/ONSdigital/dp-search-api) |
 | 24000 | [dp-publishing-dataset-controller](https://github.com/ONSdigital/dp-publishing-dataset-controller) |
 | 24100 | [dp-frontend-cookie-controller](https://github.com/ONSdigital/dp-frontend-cookie-controller) |


### PR DESCRIPTION
### What

Remove port for dp-frontend-geogrpahy-controller - service being decommissioned

### How to review

Confirm the above has been done

### Who can review

Anyone
