### PR TITLE
Remove references to frontend-renderer

### DIFF
--- a/guides/INSTALLING.md
+++ b/guides/INSTALLING.md
@@ -65,7 +65,6 @@ Clone the GitHub repos for [web](#web-journey), [publishing](#publishing-journey
 * [zebedee](https://github.com/ONSdigital/zebedee)
 * [sixteens](https://github.com/ONSdigital/sixteens)
 * [dp-frontend-router](https://github.com/ONSdigital/dp-frontend-router)
-* [dp-frontend-renderer](https://github.com/ONSdigital/dp-frontend-renderer)
 * [dp-frontend-homepage-controller](https://github.com/ONSdigital/dp-frontend-homepage-controller)
 * [dp-frontend-cookie-controller](https://github.com/ONSdigital/dp-frontend-cookie-controller)
 * [dp-frontend-dataset-controller](https://github.com/ONSdigital/dp-frontend-dataset-controller)
@@ -77,7 +76,6 @@ Clone the GitHub repos for [web](#web-journey), [publishing](#publishing-journey
   git clone git@github.com:ONSdigital/sixteens
 
   git clone git@github.com:ONSdigital/dp-frontend-router
-  git clone git@github.com:ONSdigital/dp-frontend-renderer
 
   git clone git@github.com:ONSdigital/dp-frontend-homepage-controller
   git clone git@github.com:ONSdigital/dp-frontend-cookie-controller
@@ -261,7 +259,6 @@ Run all the services in the [web journey](#web-journey)
 * [zebedee](https://github.com/ONSdigital/zebedee) - use: `$ ./run-reader.sh`
 * [sixteens](https://github.com/ONSdigital/sixteens) - use: `$ ./run.sh`
 * [dp-frontend-router](https://github.com/ONSdigital/dp-frontend-router)
-* [dp-frontend-renderer](https://github.com/ONSdigital/dp-frontend-renderer)
 * [dp-frontend-homepage-controller](https://github.com/ONSdigital/dp-frontend-homepage-controller)
 * [dp-frontend-cookie-controller](https://github.com/ONSdigital/dp-frontend-cookie-controller)
 * [dp-frontend-dataset-controller](https://github.com/ONSdigital/dp-frontend-dataset-controller)

--- a/hiring/README.md
+++ b/hiring/README.md
@@ -21,7 +21,6 @@ The only code we keep private relates to our infrastructure, which is also why t
 * [Zebedee](https://github.com/ONSdigital/zebedee) is the CMS backend, written in Java and using a custom web framework.
 * [Babbage](https://github.com/ONSdigital/babbage) runs the bulk of the ONS website, it is also written in Java using the same custom framework as Zebedee. Some of the original functionality is being broken out into Go microservices such as:
     * [Router](https://github.com/ONSdigital/dp-frontend-router)
-    * [Renderer](https://github.com/ONSdigital/dp-frontend-renderer)
     * [Dataset Controller](https://github.com/ONSdigital/dp-frontend-dataset-controller)
 * [Dataset API](https://github.com/ONSdigital/dp-dataset-api) provides the core of our new API focussed journey, written in Go and backed by our graph database.
 * [Dataset exporter](https://github.com/ONSdigital/dp-dataset-exporter) is one of our event-driven Go services, which generates custom CSV files determined by user queries.


### PR DESCRIPTION
### What

Removed references to dp-frontend-renderer as now deprecated and removed. 

### How to review

Check makes sense. 

### Who can review

Not me. 