### PR TITLE
Remove dp-areas-api from PORTS

### DIFF
--- a/guides/PORTS.md
+++ b/guides/PORTS.md
@@ -77,7 +77,6 @@ in development without having to configure them individually.
 | 25252 | [dp-find-insights-poc-api](https://github.com/ONSdigital/dp-find-insights-poc-api)                             |
 | 25300 | [dp-topic-api](https://github.com/ONSdigital/dp-topic-api)                                                     |
 | 25400 | [dp-permissions-api](https://github.com/ONSdigital/dp-permissions-api)                                         |
-| 25500 | [dp-areas-api](https://github.com/ONSdigital/dp-areas-api)                                                     |
 | 25600 | [dp-identity-api](https://github.com/ONSdigital/dp-identity-api)                                               |
 | 25700 | [dp-search-reindex-api](https://github.com/ONSdigital/dp-search-reindex-api)                                   |
 | 25800 | [dp-search-data-extractor](https://github.com/ONSdigital/dp-search-data-extractor)                             |


### PR DESCRIPTION
### What

Removed dp-areas-api from PORTS as it's being archived

### How to review

Check line is removed

### Who can review

Anyone