### PR TITLE
Stop PRs auto-assigning

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 
-* @ONSdigital/dissemination
+# The below indicates the code owners of this repo without auto-assigning PRs to the team
+
+.github/* @ONSdigital/dissemination


### PR DESCRIPTION
### What

This should stop auto-assigning PRs whilst still allowing us to have valid CODEOWNERS files. 

### How to review

We'll have to check it works after merge. 

### Who can review

Anyone in Dissemination. 