### PR TITLE
assign dis-cloudflare-stub to port 30200

### DIFF
--- a/guides/PORTS.md
+++ b/guides/PORTS.md
@@ -107,3 +107,4 @@ in development without having to configure them individually.
 | 29900 | [dis-redirect-api](https://github.com/ONSdigital/dis-redirect-api)                                             |       |
 | 30000 | [dis-redirect-proxy](https://github.com/ONSdigital/dis-redirect-proxy)                                         |       |
 | 30100 | [dis-migration-service](https://github.com/ONSdigital/dis-migration-service)                                   |       |
+| 30200 | [dis-cloudflare-stub](https://github.com/ONSdigital/dp-compose/tree/main/v2/stubs/dis-cloudflare-stub)         |       |


### PR DESCRIPTION
### What

- Assign port `30200` to `dis-cloudflare-stub`

### How to review

- Check changes are ok
- Link will not be valid until [this](https://github.com/ONSdigital/dp-compose/pull/270) PR has been merged

### Who can review

- Anyone
