### PR TITLE
Add port for design-system-chart-explorer

### DIFF
--- a/guides/PORTS.md
+++ b/guides/PORTS.md
@@ -104,3 +104,4 @@ in development without having to configure them individually.
 | 30000 | [dis-redirect-proxy](https://github.com/ONSdigital/dis-redirect-proxy)                                         |       |
 | 30100 | [dis-migration-service](https://github.com/ONSdigital/dis-migration-service)                                   |       |
 | 30200 | [dis-cloudflare-stub](https://github.com/ONSdigital/dp-compose/tree/main/v2/stubs/dis-cloudflare-stub)         |       |
+| 30300 | [design-system-chart-exporter](https://github.com/ONSdigital/design-system-chart-exporter)                     |       |


### PR DESCRIPTION
### What

Adding port assigned to the [design-system-chart-exporter](https://github.com/ONSdigital/design-system-chart-exporter).

See [comment](https://github.com/ONSdigital/design-system-chart-exporter/pull/1#discussion_r3604398200) for additional context.

### How to review

Ensure the assigned port makes sense.

### Who can review

Maintainers.
